### PR TITLE
Add missing pagination fields

### DIFF
--- a/v2.0/openapi-v2.json
+++ b/v2.0/openapi-v2.json
@@ -3714,20 +3714,18 @@
             "type": "string"
           },
           {
-            "name": "limit",
-            "description": "The maximum number of items to return in a page",
+            "name": "marker",
+            "description": "Needs not be passed or can be empty for first invocation of the API. Use the one returned in response for each subsequent call.",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           {
-            "name": "offset",
-            "description": "The item at which to begin the response",
+            "name": "limit",
+            "description": "Maximum number to be returned",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           }
         ],
         "responses": {
@@ -4423,6 +4421,13 @@
           {
             "name": "offset",
             "description": "The offset at which to begin the response. An offset of value of 0 will start at the beginning of the folder-listing. Note: If there are hidden items in your previous response, your next offset should be = offset + limit, not the # of records you received back. The default is 0.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "marker",
+            "description": "Needs not be passed or can be empty for first invocation of the API. Use the one returned in response for each subsequent call.",
             "in": "query",
             "required": false,
             "type": "string"

--- a/v2.0/openapi-v2.json
+++ b/v2.0/openapi-v2.json
@@ -3117,7 +3117,7 @@
             "required": false,
             "type": "string"
           },
-		  {
+          {
             "name": "limit",
             "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
             "in": "query",
@@ -3630,7 +3630,7 @@
             "required": false,
             "type": "string"
           },
-		  {
+          {
             "name": "limit",
             "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
             "in": "query",
@@ -4697,7 +4697,7 @@
             "required": false,
             "type": "string"
           },
-		  {
+          {
             "name": "limit",
             "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
             "in": "query",
@@ -6746,7 +6746,7 @@
               "pending"
             ]
           },
-		  {
+          {
             "name": "limit",
             "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
             "in": "query",

--- a/v2.0/openapi-v2.json
+++ b/v2.0/openapi-v2.json
@@ -3116,6 +3116,22 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+		  {
+            "name": "limit",
+            "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "description": "The offset of the item at which to begin the response.  The default is 0",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {
@@ -3613,6 +3629,22 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+		  {
+            "name": "limit",
+            "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "description": "The offset of the item at which to begin the response.  The default is 0",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {
@@ -4664,6 +4696,22 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+		  {
+            "name": "limit",
+            "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "description": "The offset of the item at which to begin the response.  The default is 0",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {
@@ -6697,6 +6745,22 @@
             "enum": [
               "pending"
             ]
+          },
+		  {
+            "name": "limit",
+            "description": "The maximum number of items to return. The default is 100 and the maximum is 1,000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "description": "The offset of the item at which to begin the response.  The default is 0",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {


### PR DESCRIPTION
Adds limit and offset query strings to end points that supposedly have it according to the documentation.

Should close  Issue #9 