### PR TITLE
fix(fields): describe fields as an unexploded array

### DIFF
--- a/v2.0/attributes/fields.yml
+++ b/v2.0/attributes/fields.yml
@@ -7,5 +7,8 @@ description: |-
 in: query
 example: "id,type,name"
 required: false
+explode: false
 schema:
-  type: string
+  type: array
+  items:
+    - type: string


### PR DESCRIPTION
### PROBLEM
I'd noted that while you can describe a fields parameter as a string, a more accurate way to describe it is an a non-exploded array of strings.

### SOLUTION
Update the fields.yml file with the alternate presentation.