### PR TITLE
Removed generic limit reference and added custom variation to correct limit docs

### DIFF
--- a/content/paths/search__get_search.yml
+++ b/content/paths/search__get_search.yml
@@ -232,9 +232,20 @@ parameters:
         - ASC
     example: ASC
 
+  - name: limit
+    description: |-
+      The maximum number of items to return.
+    in: query
+    required: false
+    example: 100
+    schema:
+      type: integer
+      format: int64
+      default: 30
+      maximum: 200
+
   - $ref: '../attributes/fields.yml'
   - $ref: '../attributes/offset.yml'
-  - $ref: '../attributes/limit.yml'
 
 responses:
   200:


### PR DESCRIPTION
Generic limit documentation referred to limit as default 100, max 1000.

The correct values are default 30, max 200 for search.

Changed this from a generic attribute to a one off limit as I believe this is the only place that the limit is 30/200.