### PR TITLE
Re-add can_view_path attribute to POST / PUT collaboration calls

### DIFF
--- a/content/attributes/collaboration_can_view_path.yml
+++ b/content/attributes/collaboration_can_view_path.yml
@@ -5,4 +5,8 @@ description: |-
   the associated folder. The user will not gain privileges in any
   parent folder and therefore can not see content the user is not
   collaborated on.
+
+  Be aware that this meaningfully increases the time required to load the
+  invitee's All Files page. We recommend you limit the number of collaborations
+  with `can_view_path` enabled to 1,000.
 example: true

--- a/content/paths/collaborations__post_collaborations.yml
+++ b/content/paths/collaborations__post_collaborations.yml
@@ -90,6 +90,9 @@ requestBody:
           role:
             $ref: '../attributes/collaboration_role.yml'
 
+          can_view_path:
+            $ref: '../attributes/collaboration_can_view_path.yml'
+
 responses:
   201:
     description: |-

--- a/content/paths/collaborations__put_collaborations_id.yml
+++ b/content/paths/collaborations__put_collaborations_id.yml
@@ -16,7 +16,6 @@ description: |-
 
 parameters:
   - $ref: '../attributes/collaboration_id.yml'
-  - $ref: '../attributes/fields.yml'
 
 requestBody:
   content:

--- a/content/paths/collaborations__put_collaborations_id.yml
+++ b/content/paths/collaborations__put_collaborations_id.yml
@@ -47,6 +47,9 @@ requestBody:
               collaboration will be automatically removed from the item.
             example: '2019-08-29T23:59:00-07:00'
 
+          can_view_path:
+            $ref: '../attributes/collaboration_can_view_path.yml'
+
 responses:
   200:
     description:


### PR DESCRIPTION
- Add missing can_view_path option back to create and update collaboration endpoints. 
- Use centralized can_view_path attribute object.
- Remove fields query param (DDOC-256).