### PR TITLE
Fix: return correct type of shared links API

### DIFF
--- a/content/paths/shared_links__get_shared_items.yml
+++ b/content/paths/shared_links__get_shared_items.yml
@@ -46,7 +46,9 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/Item--Mini'
+          oneOf:
+            - $ref: '#/components/schemas/File'
+            - $ref: '#/components/schemas/Folder'
 
   304:
     description: |-

--- a/src/spectral/ensureSchemaHasType.js
+++ b/src/spectral/ensureSchemaHasType.js
@@ -1,4 +1,5 @@
 module.exports = (schema, _, paths) => {
+  if (schema.oneOf) { return }
   if (!schema.type && !schema['$ref']) {
     return [{
       message: `${paths.target ? paths.target.join('.') : 'type or $ref'} is not truthy`,


### PR DESCRIPTION
Correct the response type for the shared links API. It returns a file or folder.