### PR TITLE
Add dedicated API docs for Skills

### DIFF
--- a/content/attributes/skill_card.yml
+++ b/content/attributes/skill_card.yml
@@ -1,0 +1,198 @@
+---
+type: object
+description: A single metadata card to apply to a file.
+required:
+  - type
+  - skill_card_type
+  - skill
+  - invocation
+properties:
+  created_at:
+    type: string
+    format: date-time
+    example: "2018-04-13T13:53:23-07:00"
+    description: |-
+      The optional date and time this card was created at.
+  type:
+    type: string
+    description: "`skill_card`"
+    example: 'skill_card'
+    enum:
+      - skill_card
+  skill_card_type:
+    description: The type of card to add to the file.
+    example: status
+    enum:
+      - transcript
+      - keyword
+      - timeline
+      - status
+  skill_card_title:
+    type: object
+    description: The title of the card.
+    required:
+      - message
+    properties:
+      code:
+        type: string
+        example: "my_transcripts"
+        description: An optional identifier for the title.
+
+      message:
+        type: string
+        example: "My Transcripts"
+        description: The actual title to show in the UI.
+
+  status:
+    type: object
+    description:
+      Used with a card of type `status` to set the status of the
+      skill. This can be used to show a message to the user while
+      the Skill is processing the data.
+    required:
+      - code
+    properties:
+      code:
+        type: string
+        description: |-
+          A code for the status of this Skill invocation. By
+          default each of these will have their own accompanied
+          messages. These can be adjusted by setting the `message`
+          value on this object.
+        example: success
+        enum:
+          - invoked
+          - processing
+          - success
+          - transient_failure
+          - permanent_failure
+      message:
+        type: string
+        description: |-
+          A custom message that can be provided with this status.
+          This will be shown in the web app to the end user.
+        example: |-
+          We're preparing to process your file. Please hold on!
+
+  skill:
+    type: object
+    description: The service that applied this metadata.
+    required:
+      - type
+      - id
+    properties:
+      type:
+        type: string
+        example: "service"
+        description: "`service`"
+        enum:
+          - service
+
+      id:
+        type: string
+        example: "image-recognition-service"
+        description: |-
+          A custom identifier that represent the service that
+          applied this metadata.
+
+      invocation:
+        type: object
+        description: |-
+          The invocation of this service, used to track
+          which instance of a service applied the metadata.
+        required:
+          - type
+          - id
+        properties:
+          type:
+            type: string
+            example: "skill_invocation"
+            description: "`skill_invocation`"
+            enum:
+              - skill_invocation
+
+          id:
+            type: string
+            example: "abc123"
+            description: |-
+              A custom identifier that represent the instance of
+              the service that applied this metadata. For example,
+              if your `image-recognition-service` runs on multiple
+              nodes, this field can be used to identify the ID of
+              the node that was used to apply the metadata.
+
+      duration:
+        type: integer
+        example: 1000
+        description: |-
+          An optional total duration in seconds.
+
+          Used with a `skill_card_type` of `transcript` or
+          `timeline`.
+
+      entries:
+        type: array
+        description: |-
+          An optional list of entries in the metadata card.
+
+          This field is used with a `skill_card_type` of
+          `transcript`, `keyword` or `timeline`.
+        items:
+          type: object
+
+          description: |-
+            An entry in the `entries` attribute of a metadata card
+          properties:
+            text:
+              type: string
+              example: "keyword1"
+              description: |-
+                The text of the entry. This would be the actual
+                keyword in a `keyword` card, the line of a
+                transcript in a `transcript` card, or the display
+                name for an item when using the `timeline` entry.
+
+            appears:
+              type: array
+              description: |-
+                Defines a list of timestamps for an entry. This is
+                used with a `skill_card_type` of `transcript` as
+                well as `timeline` to place items on a timeline.
+
+                For a `skill_card_type` of `transcript` there can
+                only be one entry in this list for each item, and
+                only the `start` time is used to place the
+                transcript on the timeline.
+              required:
+                - start
+                - end
+              items:
+                type: object
+                description: |-
+                  The timestamp for an entry.
+                properties:
+                  start:
+                    type: integer
+                    example: 1
+                    description: |-
+                      The time in seconds when an
+                      entry should start appearing on a timeline.
+                  end:
+                    type: integer
+                    example: 20
+                    description: |-
+                      The time in seconds when an
+                      entry should stop appearing on a timeline. For
+                      a `skill_card_type` of `transcript` this value
+                      is ignored.
+
+            image_url:
+              type: string
+              description: |-
+                The image to show on a for an entry that appears
+                on a timeline. This image URL is required for any
+                `timeline` cards. The image will be shown in a
+                list of items (for example faces), and clicking
+                the image will show the user where that entry
+                appears during the duration of this entry.
+              example: https://example.com/image1.jpg

--- a/content/attributes/skill_id.yml
+++ b/content/attributes/skill_id.yml
@@ -1,7 +1,7 @@
 ---
-name: skill_invocation_id
+name: skill_id
 description: |-
-  The ID of the skill invocation.
+  The ID of the skill to apply this metadata for.
 example: "33243242"
 in: path
 required: true

--- a/content/callbacks/skill_invocation.yml
+++ b/content/callbacks/skill_invocation.yml
@@ -1,12 +1,12 @@
 ---
-title: Skill invocation
+title: Skill webhook payload
 
 x-box-resource-id: skill_invocation
 
 x-box-tag: skills
 
 description: |-
-  The payload of a Box skill as sent to a Custom Skill's
+  The payload of a Box skill as sent to a skill's
   `invocation_url`.
 
 properties:

--- a/content/callbacks/webhook_invocation.yml
+++ b/content/callbacks/webhook_invocation.yml
@@ -1,5 +1,5 @@
 ---
-title: Webhook invocation
+title: Webhook (V2) payload
 
 x-box-resource-id: webhook_invocation
 

--- a/content/paths.yml
+++ b/content/paths.yml
@@ -117,6 +117,16 @@
   delete:
     "$ref": "./paths/file_metadata__delete_files_id_metadata_id_id.yml"
 
+"/files/{file_id}/metadata/global/boxSkillsCards":
+  get:
+    "$ref": "./paths/skills__get_files_id_metadata_global_boxSkillsCards.yml"
+  post:
+    "$ref": "./paths/skills__post_files_id_metadata_global_boxSkillsCards.yml"
+  put:
+    "$ref": "./paths/skills__put_files_id_metadata_global_boxSkillsCards.yml"
+  delete:
+    "$ref": "./paths/skills__delete_files_id_metadata_global_boxSkillsCards.yml"
+
 "/files/{file_id}/watermark":
   get:
     "$ref": "./paths/file_watermarks__get_files_id_watermark.yml"
@@ -409,7 +419,7 @@
   delete:
     "$ref": "./paths/webhooks__delete_webhooks_id.yml"
 
-"/skill_invocations/{skill_invocation_id}":
+"/skill_invocations/{skill_id}":
   put:
     "$ref": "./paths/skills__put_skill_invocations_id.yml"
 

--- a/content/paths/downloads__get_files_id_content.yml
+++ b/content/paths/downloads__get_files_id_content.yml
@@ -37,6 +37,22 @@ parameters:
     schema:
       type: string
 
+  - name: access_token
+    description:
+      An optional access token that can be used to pre-authenticate this
+      request, which means that a download link can be shared with a browser or
+      a third party service without them needing to know how to handle the
+      authentication.
+
+      When using this parameter, please make sure that the access token is
+      sufficiently scoped down to only allow read access to that file and no
+      other files or folders.
+    example: "c3FIOG9vSGV4VHo4QzAyg5T1JvNnJoZ3ExaVNyQWw6WjRsanRKZG5lQk9qUE1BVQ"
+    in: query
+    required: false
+    schema:
+      type: string
+
 responses:
   202:
     description: |-

--- a/content/paths/skills__delete_files_id_metadata_global_boxSkillsCards.yml
+++ b/content/paths/skills__delete_files_id_metadata_global_boxSkillsCards.yml
@@ -1,0 +1,52 @@
+---
+operationId: delete_files_id_metadata_global_boxSkillsCards
+
+summary: Remove Box Skill cards from file
+
+tags:
+  - Skills
+
+x-box-tag: skills
+x-box-sanitized: true
+
+description: |-
+  Removes any Box Skills cards metadata from a file.
+
+parameters:
+  - $ref: '../attributes/file_id.yml'
+
+responses:
+  204:
+    description: |-
+      Returns an empty response when the cards are
+      successfully deleted.
+
+  404:
+    description: |-
+      Returns an error when the file does not have an instance of the Box Skill
+      cards applied to it, or when the user does not have access to the file.
+
+      * `instance_not_found` - An instance of the metadata template for Box
+      Skill cards was not found on this file.
+      * `not_found` - The file was not found, or the user does not have access
+      to the file.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  405:
+    description: |-
+      Returned when the method was not allowed.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  default:
+    description: |-
+      An unexpected client error.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'

--- a/content/paths/skills__get_files_id_metadata_global_boxSkillsCards.yml
+++ b/content/paths/skills__get_files_id_metadata_global_boxSkillsCards.yml
@@ -1,0 +1,36 @@
+---
+operationId: get_files_id_metadata_global_boxSkillsCards
+
+summary: List Box Skill cards on file
+
+tags:
+  - Skills
+
+x-box-tag: skills
+
+description: |-
+  List the Box Skills metadata cards that are attached to a file.
+
+parameters:
+  - $ref: '../attributes/file_id.yml'
+
+responses:
+  200:
+    description: |-
+      Returns all the metadata associated with a file.
+
+      This API does not support pagination and will therefore always return
+      all of the metadata associated to the file.
+
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/Metadata'
+
+  default:
+    description: |-
+      An unexpected client error.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'

--- a/content/paths/skills__post_files_id_metadata_global_boxSkillsCards.yml
+++ b/content/paths/skills__post_files_id_metadata_global_boxSkillsCards.yml
@@ -1,0 +1,86 @@
+---
+operationId: post_files_id_metadata_global_boxSkillsCards
+
+summary: Create Box Skill cards on file
+
+tags:
+  - Skills
+
+x-box-tag: skills
+
+description: |-
+  Applies one or more Box Skills metadata cards to a file.
+
+parameters:
+  - $ref: '../attributes/file_id.yml'
+
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - cards
+
+        properties:
+          cards:
+            type: array
+            description: |-
+              A list of Box Skill cards to apply to this file.
+            items:
+              $ref: '../attributes/skill_card.yml'
+
+responses:
+  201:
+    description: |-
+      Returns the instance of the template that was applied to the file,
+      including the data that was applied to the template.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/Metadata'
+
+  400:
+    description: |-
+      Returns an error when the request body is not valid.
+
+      * `schema_validation_failed` - The request body contains a value for a for
+      a field that either does not exist, or for which the value or type does
+      not match the expected field type. An example might be an unknown option
+      for an `enum` or `multiSelect` field.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  404:
+    description: |-
+      Returns an error when the file or metadata template could not be found.
+
+      * `not_found` - The file could not be found, or the user does not have
+      access to the file.
+      * `instance_tuple_not_found` - The metadata template could not be found.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  409:
+    description: |-
+      Returns an error when an instance of this metadata template is already
+      present on the file.
+
+      * `tuple_already_exists` - An instance of them metadata template already
+      exists on the file.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  default:
+    description: |-
+      An unexpected client error.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'

--- a/content/paths/skills__put_files_id_metadata_global_boxSkillsCards.yml
+++ b/content/paths/skills__put_files_id_metadata_global_boxSkillsCards.yml
@@ -1,0 +1,92 @@
+---
+operationId: put_files_id_metadata_global_boxSkillsCards
+
+summary: Update Box Skill cards on file
+
+tags:
+  - Skills
+
+x-box-tag: skills
+
+description: |-
+  Updates one or more Box Skills metadata cards to a file.
+
+parameters:
+  - $ref: '../attributes/file_id.yml'
+
+requestBody:
+  content:
+    application/json-patch+json:
+      schema:
+        description: |-
+          A [JSON-Patch](https://tools.ietf.org/html/rfc6902)
+          specification for the changes to make to the metadata
+          template.
+
+          The changes are represented as a JSON array of
+          operation objects.
+
+        type: array
+
+        items:
+          type: object
+          description: |-
+            An operation that replaces an existing card.
+          properties:
+            op:
+              type: string
+              description: "`replace`"
+              example: replace
+              enum:
+                - replace
+            path:
+              type: string
+              description: |-
+                The JSON Path that represents the card to replace. In most cases
+                this will be in the format `/cards/{index}` where `index` is the
+                zero-indexed position of the card in the list of cards.
+              example: "/cards/0"
+            value:
+              $ref: '../attributes/skill_card.yml'
+
+responses:
+  200:
+    description: |-
+      Returns the updated metadata template, with the
+      custom template data included.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/MetadataTemplate'
+
+  400:
+    description: |-
+      The request body does not contain a valid metadata schema.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  403:
+    description: |-
+      The request body contains a scope that the user is not
+      allowed to create templates for.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  404:
+    description: The requested template could not be found
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  default:
+    description: |-
+      An unexpected client error.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'

--- a/content/paths/skills__put_skill_invocations_id.yml
+++ b/content/paths/skills__put_skill_invocations_id.yml
@@ -1,7 +1,7 @@
 ---
 operationId: put_skill_invocations_id
 
-summary: Update skill invocation
+summary: Update all Box Skill cards on file
 
 tags:
   - Skills
@@ -9,11 +9,11 @@ tags:
 x-box-tag: skills
 
 description: |-
-  Updates the status, usage and response metadata of a
-  skill invocation.
+  An alternative method that can be used to overwrite and update all Box Skill
+  metadata cards on a file.
 
 parameters:
-  - $ref: '../attributes/skill_invocation_id.yml'
+  - $ref: '../attributes/skill_id.yml'
 
 requestBody:
   content:
@@ -29,7 +29,8 @@ requestBody:
           status:
             type: string
             description:
-              Sets the status of the skill invocation.
+              Defines the status of this invocation. Set this to `success` when
+              setting Skill cards.
             example: success
             enum:
               - invoked
@@ -40,168 +41,22 @@ requestBody:
 
           metadata:
             type: object
-            description: The metadata to set for this skill
+            description: |-
+              The metadata to set for this skill. This is a list of
+              Box Skills cards. These cards will overwrite any existing Box
+              skill cards on the file.
             properties:
               cards:
-                description: The metadata cards to set on the file.
                 type: array
+                description: |-
+                  A list of Box Skill cards to apply to this file.
                 items:
-                  type: object
-
-                  description: |-
-                    A Box Skills card that is applied to the metadata
-                    of a file.
-
-                  required:
-                    - type
-                    - created_at
-                    - skill
-                    - skill_card_title
-
-                  properties:
-                    type:
-                      type: string
-                      example: "skill_card"
-                      description: "`skill_card`"
-                      enum:
-                        - skill_card
-
-                    created_at:
-                      type: string
-                      format: date-time
-                      description: The time the card was created at
-                      example: '2012-12-12T10:53:43-08:00'
-
-                    skill_card_type:
-                      type: string
-                      description: The type of card to create
-                      example: status
-                      enum:
-                        - transcript
-                        - keyword
-                        - timeline
-                        - status
-                        - error
-
-                    skill:
-                      type: object
-                      description: The skill that is updating the cards
-                      required:
-                        - type
-                        - id
-                      properties:
-                        type:
-                          type: string
-                          example: "service"
-                          description: "`service`"
-                          enum:
-                            - service
-
-                        id:
-                          type: string
-                          example: "43342423234"
-                          description: The ID of the skill.
-
-                    skill_card_title:
-                      type: object
-                      description: The title of the card
-                      required:
-                        - code
-                        - message
-                      properties:
-                        code:
-                          type: string
-                          example: "my_transcripts"
-                          description: An identifier for your title
-
-                        message:
-                          type: string
-                          example: "My Transcripts"
-                          description: The actual title to show in the UI
-
-                    invocation:
-                      type: object
-                      description: The current invocation of the skill
-                      required:
-                        - type
-                        - id
-                      properties:
-                        type:
-                          type: string
-                          example: "skill_invocation"
-                          description: "`skill_invocation`"
-                          enum:
-                            - skill_invocation
-
-                        id:
-                          type: string
-                          example: "33243242"
-                          description: The ID of the skill invocation.
-
-                    status:
-                      type: object
-                      description: |-
-                        Optional status. Used with a `card_type` of `status`.
-                      properties:
-                        code:
-                          type: string
-                          description: The type of status being set
-                          enum:
-                            - skills_pending_status
-                            - custom_error
-                          example: skills_pending_status
-
-                        message:
-                          type: string
-                          description: |-
-                            The message for the status to show in the UI.
-                          example:
-                            We're preparing to process your file. Please hold
-                            on!
-
-                    entries:
-                      description: |-
-                        An optional list of entries.
-
-                        Used with a `card_type` of`transcript`, `keyword` or
-                        `timeline`.
-                      type: array
-                      items:
-                        type: object
-
-                        description: |-
-                          An entry in the `entries` attribute of a metadata card
-
-                        required:
-                          - type
-                          - text
-
-                        properties:
-                          type:
-                            type: string
-                            example: "text"
-                            description: "`text`"
-                            enum:
-                              - text
-
-                          text:
-                            type: string
-                            example: "keyword1"
-                            description: The text of the entry
-
-                    duration:
-                      type: integer
-                      example: 1000
-                      description: |-
-                        An optional duration.
-
-                        Used with a `card_type` of`transcript`, or
-                        `timeline`.
+                  $ref: '../attributes/skill_card.yml'
 
           file:
             type: object
             description: |-
-              The file to assign this metadata to
+              The file to assign the cards to.
             properties:
               type:
                 type: string
@@ -218,7 +73,7 @@ requestBody:
           file_version:
             type: object
             description: |-
-              The file version to assign this metadata to
+              The optional file version to assign the cards to.
             properties:
               type:
                 type: string
@@ -230,12 +85,54 @@ requestBody:
                 type: string
                 description: |-
                   The ID of the file version
-                example: "3"
+                example: "731381601045"
+
+          usage:
+            type: object
+            description: |-
+              A descriptor that defines what items are affected by this call.
+
+              Set this to the default values when setting a card to a `success`
+              state, and leave it out in most other situations.
+            properties:
+              unit:
+                type: string
+                example: file
+                description: "`file`"
+              value:
+                type: number
+                example: 1
+                description: "`1`"
 
 responses:
   200:
     description: |-
-      Returns an empty response.
+      Returns an empty response when the card has been successfully updated.
+
+  400:
+    description: |-
+      Returns an error when the request body is not valid.
+
+      * `schema_validation_failed` - The request body contains a value for a for
+      a field that either does not exist, or for which the value or type does
+      not match the expected field type. An example might be an unknown option
+      for an `enum` or `multiSelect` field.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  404:
+    description: |-
+      Returns an error when the file could not be found or the user does not
+      have access.
+
+      * `not_found` - The file could not be found, or the user does not have
+      access to the file.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
 
   default:
     description: |-


### PR DESCRIPTION
Adds dedicated API docs for Box Skills. Before this the existing docs were out of date and rolled into the generic metadata docs.