### PR TITLE
Fix shared link access level documentation

### DIFF
--- a/content/attributes/shared_link-writable.yml
+++ b/content/attributes/shared_link-writable.yml
@@ -14,14 +14,14 @@ properties:
       within the company (`company`) and only those who
       have been invited to the folder (`collaborators`).
 
-      This field defaults to the `default` access level,
-      which is the access level as specified by the
-      enterprise admin.
+      If not set, this field defaults to the access level specified
+      by the enterprise admin. To create a shared link with this
+      default setting pass the `shared_link` object with
+      no `access` field, for example `{ "shared_link": {} }`.
 
       The `company` access level is only available to paid
       accounts.
     enum:
-      - default
       - open
       - company
       - collaborators


### PR DESCRIPTION
Fixes incorrect documentation regarding setting a shared link to its default access level.

Re `DDOC-353`