### PR TITLE
Improve search specficiation regarding metadata filters

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -101,6 +101,16 @@ rules:
     then:
       function: ensurePropertiesExample
 
+  ensure-additional-properties-oneof-example:
+    description: Additional properties (oneOf) must have examples.
+    given: $..*.additionalProperties.oneOf[*]
+    severity: error
+    recommended: true
+    resolved: true
+    message: "{{error}}"
+    then:
+      function: ensurePropertiesExample
+
   ensure-allof-order:
     description: Ensures order of items in an allOf
     given: '$..*.allOf'

--- a/content/paths/metadata_cascade_policies__post_metadata_cascade_policies.yml
+++ b/content/paths/metadata_cascade_policies__post_metadata_cascade_policies.yml
@@ -52,6 +52,19 @@ requestBody:
               The key of the targeted metadata template. This template will
               need to already have an instance applied to the targeted folder.
 
+              In many cases the template key is automatically derived
+              of its display name, for example `Contract Template` would
+              become `contractTemplate`. In some cases the creator of the
+              template will have provided its own template key.
+
+              Please [list the templates for an enterprise][list], or
+              get all instances on a [file][file] or [folder][folder]
+              to inspect a template's key.
+
+              [list]: e://get-metadata-templates-enterprise
+              [file]: e://get-files-id-metadata
+              [folder]: e://get-folders-id-metadata
+
 responses:
   201:
     description: |-

--- a/content/paths/search__get_search.yml
+++ b/content/paths/search__get_search.yml
@@ -185,25 +185,29 @@ parameters:
 
   - name: mdfilters
     description: |-
-      A list of metadata templates to filter
-      search results by.
+      A list containing 1 metadata template to filter
+      search results by. This list can currently only
+      contain one entry.
 
       Required unless `query` is defined.
     in: query
+
     example:
       - scope: enterprise
-        templateKey: contractTemplate
+        templateKey: contract
         filters:
           category: online
     x-example:
       - scope: enterprise
-        templateKey: contractTemplate
+        templateKey: contract
         filters:
           category: online
           contractValue: 1000000
     required: false
     schema:
       type: array
+      minItems: 1
+      maxItems: 1
       items:
         $ref: "#/components/schemas/MetadataFilter"
       description: |-

--- a/content/paths/search__get_search.yml
+++ b/content/paths/search__get_search.yml
@@ -166,7 +166,6 @@ parameters:
       enum:
         - file
         - folder
-        - web_link
 
   - name: trash_content
     description: |-
@@ -246,7 +245,7 @@ parameters:
 
       * `relevance` (default) returns the results sorted by relevance to the
       query search term.
-      * `modified_at`  returns the results ordered in descending order by date
+      * `modified_at` returns the results ordered in descending order by date
       at which the item was last modified.
     in: query
     required: false
@@ -298,7 +297,7 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/Items'
+          $ref: '#/components/schemas/SearchResults'
 
   default:
     description: |-

--- a/content/paths/search__get_search.yml
+++ b/content/paths/search__get_search.yml
@@ -18,8 +18,10 @@ parameters:
       The string to search for. This query is matched against item names,
       descriptions, text content of files, and various other fields of
       the different item types.
+
+      Required unless `mdfilters` parameter is defined.
     in: query
-    required: true
+    required: false
     example: sales
     schema:
       type: string
@@ -183,61 +185,26 @@ parameters:
 
   - name: mdfilters
     description: |-
-      Limits search results to items that match the
-      metadata template name and content.
+      A list of metadata templates to filter
+      search results by.
+
+      Required unless `query` is defined.
     in: query
-    required: false
     example:
       - scope: enterprise
-        templateKey: marketingCollateral
+        templateKey: contractTemplate
         filters:
-          documentType: datasheet
+          category: online
+          value: 10000
+    required: false
     schema:
       type: array
       items:
-        type: object
+        $ref: "#/components/schemas/MetadataFilter"
+      description: |-
+        A list of metadata templates to filter the search results by.
 
-        description: |-
-          A metadata filter used for searching by metadata
-          template
-
-        properties:
-          scope:
-            description: |-
-              Specifies the scope of the template to search for.
-            type: string
-            example: global
-            enum:
-              - global
-              - enterprise
-
-          templateKey:
-            description: |-
-              The key name of the template to search for. Only
-              one template name can be specified per filter.
-            type: string
-            example: marketingCollateral
-
-          filters:
-            type: object
-            description: |-
-              Additional key/value pairs for the template to search for.
-
-              For floats and dates, you can include an (inclusive) upper
-              bound parameter `lt` or (inclusive) lower bound parameter
-              `gt`, or both.
-
-              An example filter for a `contractExpiration` on or before
-              `08-01-16 UTC` would be listed as follow.
-
-              `{"contractExpiration":{"lt":"2016-08-01T00:00:00Z"}}`
-            example:
-              documentType: datasheet
-            additionalProperties:
-              description: The value for the custom field
-              type: string
-              example: "datasheet"
-              x-box-example-key: documentType
+        Required unless `query` parameter is defined.
 
   - name: sort
     description: |-

--- a/content/paths/search__get_search.yml
+++ b/content/paths/search__get_search.yml
@@ -195,7 +195,12 @@ parameters:
         templateKey: contractTemplate
         filters:
           category: online
-          value: 10000
+    x-example:
+      - scope: enterprise
+        templateKey: contractTemplate
+        filters:
+          category: online
+          contractValue: 1000000
     required: false
     schema:
       type: array

--- a/content/responses/metadata_cascade_policy.yml
+++ b/content/responses/metadata_cascade_policy.yml
@@ -71,3 +71,16 @@ properties:
     description: |-
       The key of the of the template that is cascaded down to the folder's
       children.
+
+      In many cases the template key is automatically derived
+      of its display name, for example `Contract Template` would
+      become `contractTemplate`. In some cases the creator of the
+      template will have provided its own template key.
+
+      Please [list the templates for an enterprise][list], or
+      get all instances on a [file][file] or [folder][folder]
+      to inspect a template's key.
+
+      [list]: e://get-metadata-templates-enterprise
+      [file]: e://get-files-id-metadata
+      [folder]: e://get-folders-id-metadata

--- a/content/responses/metadata_field_filter_date_range.yml
+++ b/content/responses/metadata_field_filter_date_range.yml
@@ -1,0 +1,40 @@
+---
+title: Metadata field filter (date range)
+
+type: object
+x-box-resource-id: metadata_field_filter_date_range
+
+description: |-
+  Specifies which `date` field on the template to filter the search
+  results by, specifying a range of dates that can match.
+example:
+  expirationDate:
+    lt: "2017-08-01T00:00:00Z"
+    gt: "2016-08-01T00:00:00Z"
+
+additionalProperties:
+  type: object
+  description: Match a `date` metadata field to a range of values.
+  example:
+    lt: "2017-08-01T00:00:00Z"
+    gt: "2016-08-01T00:00:00Z"
+  x-box-example-key: expirationDate
+  properties:
+    lt:
+      description: |-
+        Specifies the (inclusive) upper bound for the metadata field
+        value. The value of a field must be lower than (`lt`) or
+        equal to this value for the search query to match this
+        template.
+      type: string
+      format: date-time
+      example: "2017-08-01T00:00:00Z"
+    gt:
+      description: |-
+        Specifies the (inclusive) lower bound for the metadata field
+        value. The value of a field must be greater than (`gt`) or
+        equal to this value for the search query to match this
+        template.
+      type: string
+      format: date-time
+      example: "2016-08-01T00:00:00Z"

--- a/content/responses/metadata_field_filter_float.yml
+++ b/content/responses/metadata_field_filter_float.yml
@@ -1,0 +1,19 @@
+---
+title: Metadata field filter (float)
+
+type: object
+x-box-resource-id: metadata_field_filter_float
+
+description: |-
+  Specifies which `float` field on the template to filter the search
+  results by.
+example:
+  contractValue: 10000
+
+additionalProperties:
+  type: number
+  description: |-
+    A mapping between a metadata `float` field key and
+    the value to match search results on.
+  example: 10000
+  x-box-example-key: "contractValue"

--- a/content/responses/metadata_field_filter_float_range.yml
+++ b/content/responses/metadata_field_filter_float_range.yml
@@ -1,0 +1,40 @@
+---
+title: Metadata field filter (float range)
+
+type: object
+x-box-resource-id: metadata_field_filter_float_range
+
+description: |-
+  Specifies which `float` field on the template to filter the search
+  results by, specifying a range of values that can match.
+example:
+  contractValue:
+    gt: 100000
+    lt: 200000
+
+additionalProperties:
+  type: object
+  description: |-
+    Specifies which `float` field on the template to filter the search
+    results by, specifying a range of values that can match.
+  example:
+    gt: 100000
+    lt: 200000
+  x-box-example-key: value
+  properties:
+    lt:
+      description: |-
+        Specifies the (inclusive) upper bound for the metadata field
+        value. The value of a field must be lower than (`lt`) or
+        equal to this value for the search query to match this
+        template.
+      type: number
+      example: 200000
+    gt:
+      description: |-
+        Specifies the (inclusive) lower bound for the metadata field
+        value. The value of a field must be greater than (`gt`) or
+        equal to this value for the search query to match this
+        template.
+      type: number
+      example: 100000

--- a/content/responses/metadata_field_filter_multi_select.yml
+++ b/content/responses/metadata_field_filter_multi_select.yml
@@ -6,7 +6,8 @@ x-box-resource-id: metadata_field_filter_multi_select
 
 description: |-
   Specifies the values to match for a `multiSelect` metadata
-  field
+  field. A template will match when all values are present in the
+  `multiSelect` field.
 example:
   category: ["online", "enterprise"]
 
@@ -14,7 +15,9 @@ additionalProperties:
   type: array
   description: |-
     A mapping between a metadata `multiSelect` field key and
-    the one or more values to match search results on.
+    the one or more values to match search results on. A
+    template will match when all values are present in the
+    `multiSelect` field.
   example: ["online", "enterprise"]
   items:
     type: string

--- a/content/responses/metadata_field_filter_multi_select.yml
+++ b/content/responses/metadata_field_filter_multi_select.yml
@@ -6,8 +6,9 @@ x-box-resource-id: metadata_field_filter_multi_select
 
 description: |-
   Specifies the values to match for a `multiSelect` metadata
-  field. A template will match when all values are present in the
-  `multiSelect` field.
+  field. When performing a search, the query will essentially
+  perform an `OR` operation to match any template where any of
+  the provided values match this field.
 example:
   category: ["online", "enterprise"]
 
@@ -15,9 +16,11 @@ additionalProperties:
   type: array
   description: |-
     A mapping between a metadata `multiSelect` field key and
-    the one or more values to match search results on. A
-    template will match when all values are present in the
-    `multiSelect` field.
+    the one or more values to match search results on.
+
+    When performing a search, the query will essentially
+    perform an `OR` operation to match any template where any of
+    the provided values match this field.
   example: ["online", "enterprise"]
   items:
     type: string

--- a/content/responses/metadata_field_filter_multi_select.yml
+++ b/content/responses/metadata_field_filter_multi_select.yml
@@ -1,0 +1,21 @@
+---
+title: Metadata field filter (multi-select)
+
+type: object
+x-box-resource-id: metadata_field_filter_multi_select
+
+description: |-
+  Specifies the values to match for a `multiSelect` metadata
+  field
+example:
+  category: ["online", "enterprise"]
+
+additionalProperties:
+  type: array
+  description: |-
+    A mapping between a metadata `multiSelect` field key and
+    the one or more values to match search results on.
+  example: ["online", "enterprise"]
+  items:
+    type: string
+  x-box-example-key: category

--- a/content/responses/metadata_field_filter_string.yml
+++ b/content/responses/metadata_field_filter_string.yml
@@ -1,0 +1,19 @@
+---
+title: Metadata field filter (string)
+
+type: object
+x-box-resource-id: metadata_field_filter_string
+
+description: |-
+  Specifies which text field on the template to filter the search
+  results by.
+example:
+  category: online
+
+additionalProperties:
+  type: string
+  description: |-
+    A mapping between a metadata `string` field key and
+    the value to match search results on.
+  example: "online"
+  x-box-example-key: category

--- a/content/responses/metadata_filter.yml
+++ b/content/responses/metadata_filter.yml
@@ -28,8 +28,21 @@ properties:
   templateKey:
     description: |-
       The key of the template to filter search results by.
+
+      In many cases the template key is automatically derived
+      of its display name, for example `Contract Template` would
+      become `contractTemplate`. In some cases the creator of the
+      template will have provided its own template key.
+
+      Please [list the templates for an enterprise][list], or
+      get all instances on a [file][file] or [folder][folder]
+      to inspect a template's key.
+
+      [list]: e://get-metadata-templates-enterprise
+      [file]: e://get-files-id-metadata
+      [folder]: e://get-folders-id-metadata
     type: string
-    example: contractTemplate
+    example: contract
 
   filters:
     allOf:
@@ -41,7 +54,9 @@ properties:
           - $ref: '#/components/schemas/MetadataFieldFilterDateRange'
       - description: |-
           Specifies which fields on the template to filter the search
-          results by.
+          results by. When more than one field is specified, the query
+          performs a logical `AND` to ensure that the instance of the
+          template matches each of the fields specified.
       - example:
           category: online
           contractValue: 1000000

--- a/content/responses/metadata_filter.yml
+++ b/content/responses/metadata_filter.yml
@@ -1,0 +1,146 @@
+---
+title: Metadata Filter
+
+type: object
+
+x-box-resource-id: metadata_filter
+
+x-box-tag: search
+
+description: |-
+  A metadata template to filter the search results by.
+
+properties:
+  scope:
+    description: |-
+      Specifies the scope of the template to filter search results by.
+
+      This will be `enterprise_{enterprise_id}` for templates defined
+      for use in this enterprise, and `global` for general templates
+      that are available to all enterprises using Box.
+    type: string
+    example: enterprise
+    enum:
+      - global
+      - enterprise
+      - enterprise_{enterprise_id}
+
+  templateKey:
+    description: |-
+      The key of the template to filter search results by.
+    type: string
+    example: contractTemplate
+
+  filters:
+    type: object
+    description: |-
+      Specifies which fields on the template to filter the search
+      results by.
+
+      Contains a list of key-value pairs that map to keys on
+      the metadata template and their associated values.
+
+      For floats and dates, a search can include an (inclusive) upper
+      bound parameter `lt`, a (inclusive) lower bound parameter
+      `gt`, or both.
+
+      An example, to filter for a `expirationDate` value before
+      August 1st, 2016 (UTC) filter for
+      `{"expirationDate":{"lt":"2016-08-01T00:00:00Z"}}`
+      could be applied.
+
+    example:
+      category: online
+    additionalProperties:
+      oneOf:
+        - type: string
+          description: Match a metadata field to its string value.
+          example: "online"
+          x-box-example-key: category
+
+        - type: number
+          description: Match a `float` metadata field to its numerical value.
+          example: 100000
+          x-box-example-key: value
+
+        - type: array
+          description: |-
+            Match a metadata `multiSelect` field to one or more of its values.
+          example: ["online", "enterprise"]
+          items:
+            type: string
+          x-box-example-key: category
+
+        - type: object
+          description: Match a `float` metadata field to a range of values.
+          example:
+            gt: 100000
+            lt: 200000
+          x-box-example-key: value
+          properties:
+            lt:
+              description: |-
+                Specifies the (inclusive) upper bound for the metadata field
+                value. The value of a field must be lower than (`lt`) or
+                equal to this value for the search query to match this
+                template.
+              type: number
+              example: 200000
+            gt:
+              description: |-
+                Specifies the (inclusive) lower bound for the metadata field
+                value. The value of a field must be greater than (`gt`) or
+                equal to this value for the search query to match this
+                template.
+              type: number
+              example: 100000
+
+        - type: object
+          description: Match a `date` metadata field to a range of values.
+          example:
+            lt: "2017-08-01T00:00:00Z"
+            gt: "2016-08-01T00:00:00Z"
+          x-box-example-key: expirationDate
+          properties:
+            lt:
+              description: |-
+                Specifies the (inclusive) upper bound for the metadata field
+                value. The value of a field must be lower than (`lt`) or
+                equal to this value for the search query to match this
+                template.
+              type: string
+              format: date-time
+              example: "2017-08-01T00:00:00Z"
+            gt:
+              description: |-
+                Specifies the (inclusive) lower bound for the metadata field
+                value. The value of a field must be greater than (`gt`) or
+                equal to this value for the search query to match this
+                template.
+              type: string
+              format: date-time
+              example: "2016-08-01T00:00:00Z"
+
+        - type: object
+          description: Match a `float` metadata field to a range of values.
+          example:
+            lt: 200000
+            gt: 100000
+          x-box-example-key: value
+          properties:
+            lt:
+              description: |-
+                Specifies the (inclusive) upper bound for the metadata field
+                value. The value of a field must be lower than (`lt`) or
+                equal to this value for the search query to match this
+                template.
+              type: number
+              example: 200000
+            gt:
+              description: |-
+                Specifies the (inclusive) lower bound for the metadata field
+                value. The value of a field must be greater than (`gt`) or
+                equal to this value for the search query to match this
+                template.
+              type: number
+              example: 100000

--- a/content/responses/metadata_filter.yml
+++ b/content/responses/metadata_filter.yml
@@ -1,5 +1,5 @@
 ---
-title: Metadata Filter
+title: Metadata filter
 
 type: object
 
@@ -32,115 +32,16 @@ properties:
     example: contractTemplate
 
   filters:
-    type: object
-    description: |-
-      Specifies which fields on the template to filter the search
-      results by.
-
-      Contains a list of key-value pairs that map to keys on
-      the metadata template and their associated values.
-
-      For floats and dates, a search can include an (inclusive) upper
-      bound parameter `lt`, a (inclusive) lower bound parameter
-      `gt`, or both.
-
-      An example, to filter for a `expirationDate` value before
-      August 1st, 2016 (UTC) filter for
-      `{"expirationDate":{"lt":"2016-08-01T00:00:00Z"}}`
-      could be applied.
-
-    example:
-      category: online
-    additionalProperties:
-      oneOf:
-        - type: string
-          description: Match a metadata field to its string value.
-          example: "online"
-          x-box-example-key: category
-
-        - type: number
-          description: Match a `float` metadata field to its numerical value.
-          example: 100000
-          x-box-example-key: value
-
-        - type: array
-          description: |-
-            Match a metadata `multiSelect` field to one or more of its values.
-          example: ["online", "enterprise"]
-          items:
-            type: string
-          x-box-example-key: category
-
-        - type: object
-          description: Match a `float` metadata field to a range of values.
-          example:
-            gt: 100000
-            lt: 200000
-          x-box-example-key: value
-          properties:
-            lt:
-              description: |-
-                Specifies the (inclusive) upper bound for the metadata field
-                value. The value of a field must be lower than (`lt`) or
-                equal to this value for the search query to match this
-                template.
-              type: number
-              example: 200000
-            gt:
-              description: |-
-                Specifies the (inclusive) lower bound for the metadata field
-                value. The value of a field must be greater than (`gt`) or
-                equal to this value for the search query to match this
-                template.
-              type: number
-              example: 100000
-
-        - type: object
-          description: Match a `date` metadata field to a range of values.
-          example:
-            lt: "2017-08-01T00:00:00Z"
-            gt: "2016-08-01T00:00:00Z"
-          x-box-example-key: expirationDate
-          properties:
-            lt:
-              description: |-
-                Specifies the (inclusive) upper bound for the metadata field
-                value. The value of a field must be lower than (`lt`) or
-                equal to this value for the search query to match this
-                template.
-              type: string
-              format: date-time
-              example: "2017-08-01T00:00:00Z"
-            gt:
-              description: |-
-                Specifies the (inclusive) lower bound for the metadata field
-                value. The value of a field must be greater than (`gt`) or
-                equal to this value for the search query to match this
-                template.
-              type: string
-              format: date-time
-              example: "2016-08-01T00:00:00Z"
-
-        - type: object
-          description: Match a `float` metadata field to a range of values.
-          example:
-            lt: 200000
-            gt: 100000
-          x-box-example-key: value
-          properties:
-            lt:
-              description: |-
-                Specifies the (inclusive) upper bound for the metadata field
-                value. The value of a field must be lower than (`lt`) or
-                equal to this value for the search query to match this
-                template.
-              type: number
-              example: 200000
-            gt:
-              description: |-
-                Specifies the (inclusive) lower bound for the metadata field
-                value. The value of a field must be greater than (`gt`) or
-                equal to this value for the search query to match this
-                template.
-              type: number
-              example: 100000
+    allOf:
+      - anyOf:
+          - $ref: '#/components/schemas/MetadataFieldFilterString'
+          - $ref: '#/components/schemas/MetadataFieldFilterFloat'
+          - $ref: '#/components/schemas/MetadataFieldFilterMultiSelect'
+          - $ref: '#/components/schemas/MetadataFieldFilterFloatRange'
+          - $ref: '#/components/schemas/MetadataFieldFilterDateRange'
+      - description: |-
+          Specifies which fields on the template to filter the search
+          results by.
+      - example:
+          category: online
+          contractValue: 1000000

--- a/content/responses/search_results.yml
+++ b/content/responses/search_results.yml
@@ -1,0 +1,46 @@
+---
+title: Search Results
+
+type: object
+
+x-box-resource-id: search_results
+x-box-tag: search
+
+description: |-
+  A list of files and folders that matched the search query.
+
+properties:
+  total_count:
+    description: |-
+      One greater than the offset of the last entry in the search results.
+      The total number of entries in the collection may be less than
+      `total_count`.
+    example: 5000
+    type: integer
+    format: int64
+
+  limit:
+    description: |-
+      The limit that was used for this search. This will be the same as the
+      `limit` query parameter unless that value exceeded the maximum value
+      allowed.
+    example: 1000
+    type: integer
+    format: int64
+
+  offset:
+    description: |-
+      The 0-based offset of the first entry in this set. This will be the same
+      as the `offset` query parameter used.
+    example: 2000
+    type: integer
+    format: int64
+
+  entries:
+    description: |-
+      The search results for the query provided.
+    type: array
+    items:
+      oneOf:
+        - $ref: '#/components/schemas/File'
+        - $ref: '#/components/schemas/Folder'

--- a/content/schemas.yml
+++ b/content/schemas.yml
@@ -211,9 +211,6 @@ MetadataCascadePolicy:
 MetadataCascadePolicies:
   "$ref": "./responses/metadata_cascade_policies.yml"
 
-MetadataFilter:
-  "$ref": "./responses/metadata_filter.yml"
-
 MetadataQueryResults:
   "$ref": "./responses/metadata_query_results.yml"
 
@@ -380,3 +377,23 @@ TranscriptSkillCard:
 
 StatusSkillCard:
   "$ref": "./schemas/status_skill_card.yml"
+
+#### SEARCH EXTRAS ######
+
+MetadataFilter:
+  "$ref": "./responses/metadata_filter.yml"
+
+MetadataFieldFilterString:
+  "$ref": "./responses/metadata_field_filter_string.yml"
+
+MetadataFieldFilterFloat:
+  "$ref": "./responses/metadata_field_filter_float.yml"
+
+MetadataFieldFilterMultiSelect:
+  "$ref": "./responses/metadata_field_filter_multi_select.yml"
+
+MetadataFieldFilterFloatRange:
+  "$ref": "./responses/metadata_field_filter_float_range.yml"
+
+MetadataFieldFilterDateRange:
+  "$ref": "./responses/metadata_field_filter_date_range.yml"

--- a/content/schemas.yml
+++ b/content/schemas.yml
@@ -250,6 +250,9 @@ RetentionPolicyAssignment:
 RetentionPolicyAssignments:
   "$ref": "./responses/retention_policy_assignments.yml"
 
+SearchResults:
+  "$ref": "./responses/search_results.yml"
+
 SkillCardsMetadata:
   "$ref": "./responses/skill_cards_metadata.yml"
 

--- a/content/schemas.yml
+++ b/content/schemas.yml
@@ -211,6 +211,9 @@ MetadataCascadePolicy:
 MetadataCascadePolicies:
   "$ref": "./responses/metadata_cascade_policies.yml"
 
+MetadataFilter:
+  "$ref": "./responses/metadata_filter.yml"
+
 MetadataQueryResults:
   "$ref": "./responses/metadata_query_results.yml"
 

--- a/src/spectral/ensurePropertiesExample.js
+++ b/src/spectral/ensurePropertiesExample.js
@@ -17,6 +17,8 @@ module.exports =(item, _, paths) => {
       // skip if the property as a reference
       item['$ref'] !== undefined ||
       item.allOf !== undefined ||
+      // if this is a list 
+      item.oneOf !== undefined ||
       // allow an explicit example value of null
       item.example === null ) { return }
   


### PR DESCRIPTION
Attempts to improve the search API to better document the `mdfilters` param.

* adds a new Spectral rule to check example of oneOf/anyof fields
* marks query as only required of mdfilters not set
* improves examples
* extracts mdfilters into own object
* extract different variants of `mdfilters.filters` into seperate field filter objects

Re DDOC/356
Re DDOC/317

Estimated go-live 28.8

