### PR TITLE
Add clarification to file/folder collab endpoints

### DIFF
--- a/content/paths/list_collaborations__get_files_id_collaborations.yml
+++ b/content/paths/list_collaborations__get_files_id_collaborations.yml
@@ -4,8 +4,9 @@ operationId: get_files_id_collaborations
 summary: List file collaborations
 
 description: |-
-  Retrieves a list of collaborations for a file. This
-  returns all the users that have access to the file.
+  Retrieves a list of pending and active collaborations for a
+  file. This returns all the users that have access to the file
+  or have been invited to the file.
 
 tags:
   - Collaborations (List)
@@ -23,6 +24,10 @@ responses:
     description: |-
       Returns a collection of collaboration objects. If there are no
       collaborations on this file an empty collection will be returned.
+
+      This list includes pending collaborations, for which the `status`
+      is set to `pending`, indicating invitations that have been sent but not
+      yet accepted.
     content:
       application/json:
         schema:

--- a/content/paths/list_collaborations__get_folders_id_collaborations.yml
+++ b/content/paths/list_collaborations__get_folders_id_collaborations.yml
@@ -4,8 +4,9 @@ operationId: get_folders_id_collaborations
 summary: List folder collaborations
 
 description: |-
-  Retrieves a list of collaborations for a folder. This
-  returns all the users that have access to the folder.
+  Retrieves a list of pending and active collaborations for a
+  folder. This returns all the users that have access to the folder
+  or have been invited to the folder.
 
 tags:
   - Collaborations (List)
@@ -21,6 +22,10 @@ responses:
     description: |-
       Returns a collection of collaboration objects. If there are no
       collaborations on this folder an empty collection will be returned.
+
+      This list includes pending collaborations, for which the `status`
+      is set to `pending`, indicating invitations that have been sent but not
+      yet accepted.
     content:
       application/json:
         schema:


### PR DESCRIPTION
Add clarification to file/folder collab endpoints to specifically state that pending collaborations are returned
