### PR TITLE
Remove use_index from MDQ search request

### DIFF
--- a/content/requests/metadata_query.yml
+++ b/content/requests/metadata_query.yml
@@ -60,18 +60,6 @@ properties:
       corresponding to the ID or in any of its subfolders.
     example: "0"
 
-  use_index:
-    type: string
-    description: |-
-      The name of the search index to use for this query. A search index is
-      required when a metadata template is assigned to more than 10,000 files
-      and folders.
-
-      Please contact our
-      [Metadata Query team](mailto:metadata-query-feedback@box.com)
-      to create a search index.
-    example: "amountAsc"
-
   order_by:
     type: array
     description: |-


### PR DESCRIPTION
# Description
The `use_index` parameter on a metadata query search request is no longer in use. Use of the parameter will be ignored and instead the MDQ service will choose the most efficient index to use from those available. This PR removes the `use_index` parameter from the endpoint definition.

Fixes `DDOC-395`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
