### PR TITLE
Ddoc 191 token downscoping

### DIFF
--- a/content/requests/post_oauth2_token.yml
+++ b/content/requests/post_oauth2_token.yml
@@ -153,3 +153,10 @@ properties:
       Used in combination with `client_credentials` as the `grant_type`.
       Value is determined by `box_subject_type`. If `user` use user ID and if
       `enterprise` use enterprise ID.
+
+  box_shared_link:
+      type: string
+      format: url
+      description: |-
+        Full URL of the shared link on the file or folder that the token should be generated for.
+      example: https://cloud.box.com/s//123456

--- a/content/requests/post_oauth2_token.yml
+++ b/content/requests/post_oauth2_token.yml
@@ -158,7 +158,6 @@ properties:
     type: string
     format: url
     description: |-
-      Full URL of the shared link on the file or folder 
+      Full URL of the shared link on the file or folder
       that the token should be generated for.
     example: https://cloud.box.com/s/123456
-    

--- a/content/requests/post_oauth2_token.yml
+++ b/content/requests/post_oauth2_token.yml
@@ -159,4 +159,4 @@ properties:
       format: url
       description: |-
         Full URL of the shared link on the file or folder that the token should be generated for.
-      example: https://cloud.box.com/s//123456
+      example: https://cloud.box.com/s/123456

--- a/content/requests/post_oauth2_token.yml
+++ b/content/requests/post_oauth2_token.yml
@@ -155,8 +155,10 @@ properties:
       `enterprise` use enterprise ID.
 
   box_shared_link:
-      type: string
-      format: url
-      description: |-
-        Full URL of the shared link on the file or folder that the token should be generated for.
-      example: https://cloud.box.com/s/123456
+    type: string
+    format: url
+    description: |-
+      Full URL of the shared link on the file or folder 
+      that the token should be generated for.
+    example: https://cloud.box.com/s/123456
+    


### PR DESCRIPTION
# Description
Updated token documentation in guides and api reference to add:
box_shared_link
OPTIONAL. A canonical URL that represents a link to a file or folder on Box. Password protected links are not supported in the first iteration. Vanity links may be used. Cannot co-exist with "resource". Cannot use a shared link created on a weblink.

Fixes # (issue)
`[DDOC-# 191]`(https://jira.inside-box.net/browse/DDOC-191)

Test Results:
<img width="1159" alt="Screen Shot 2021-04-12 at 2 56 05 PM" src="https://user-images.githubusercontent.com/30911851/114454936-c4936a00-9ba0-11eb-9ca7-9a343fa95d5b.png">



