### PR TITLE
Fix url in File Request response

### DIFF
--- a/content/responses/file_request.yml
+++ b/content/responses/file_request.yml
@@ -116,7 +116,7 @@ properties:
     description: |-
       The generated URL for this file request. This URL can be shared
       with users to let them upload files to the associated folder.
-    example: https://cloud.app.box.com/f/19e57f40ace247278a8e3d336678c64a
+    example: /f/19e57f40ace247278a8e3d336678c64a
     readOnly: true
 
   etag:


### PR DESCRIPTION
# Description

Fix url format to better reflect what is returned from the API (lack of protocol and hostname). See also [Java SDK change
](https://github.com/box/box-java-sdk/pull/906)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
