### PR TITLE
Fix TrackingCode schema

### DIFF
--- a/content/paths/users__post_users.yml
+++ b/content/paths/users__post_users.yml
@@ -93,15 +93,13 @@ requestBody:
 
           tracking_codes:
             type: array
+            items:
+              $ref: '#/components/schemas/TrackingCode'
             description: |-
               Tracking codes allow an admin to generate reports from the
               admin console and assign an attribute to a specific group
               of users. This setting must be enabled for an enterprise before it
               can be used.
-            example:
-              - "code1: 12345"
-            items:
-              type: string
 
           can_see_managed_users:
             type: boolean

--- a/content/paths/users__put_users_id.yml
+++ b/content/paths/users__put_users_id.yml
@@ -91,15 +91,13 @@ requestBody:
 
           tracking_codes:
             type: array
+            items:
+              $ref: '#/components/schemas/TrackingCode'
             description: |-
               Tracking codes allow an admin to generate reports from the
               admin console and assign an attribute to a specific group
               of users. This setting must be enabled for an enterprise before it
               can be used.
-            example:
-              - "code1: 12345"
-            items:
-              type: string
 
           can_see_managed_users:
             type: boolean

--- a/content/responses/user--full.yml
+++ b/content/responses/user--full.yml
@@ -24,36 +24,13 @@ allOf:
 
       tracking_codes:
         type: array
+        items:
+          $ref: '#/components/schemas/TrackingCode'
         description: |-
           Tracking codes allow an admin to generate reports from the
           admin console and assign an attribute to a specific group
           of users. This setting must be enabled for an enterprise
           before it can be used.
-        items:
-          type: object
-
-          description: |-
-            Custom tracking code for a user.
-
-          properties:
-            type:
-              type: string
-              description: "`tracking_code`"
-              example: tracking_code
-              enum:
-                - tracking_code
-
-            name:
-              type: string
-              description: |-
-                The name of the tracking code, which must be preconfigured in
-                the Admin Console
-              example: department
-
-            value:
-              type: string
-              description: The value of the tracking code
-              example: Sales
 
       can_see_managed_users:
         type: boolean

--- a/content/schemas.yml
+++ b/content/schemas.yml
@@ -444,6 +444,9 @@ SignRequestSignerInput:
 SignRequestSigner:
   "$ref": "./schemas/sign_request_signer.yml"
 
+TrackingCode:
+  "$ref": "./schemas/tracking_code.yml"
+
 #### SEARCH EXTRAS ######
 
 MetadataFilter:

--- a/content/schemas/tracking_code.yml
+++ b/content/schemas/tracking_code.yml
@@ -1,0 +1,27 @@
+---
+title: Tracking code
+
+type: object
+
+description: |-
+  Tracking codes allow an admin to generate reports from the admin console
+  and assign an attribute to a specific group of users.
+  This setting must be enabled for an enterprise before it can be used.
+
+properties:
+  type:
+    type: string
+    description: "`tracking_code`"
+    example: tracking_code
+    enum:
+      - tracking_code
+  name:
+    type: string
+    description: |-
+      The name of the tracking code, which must be preconfigured in
+      the Admin Console
+    example: department
+  value:
+    type: string
+    description: The value of the tracking code
+    example: Sales


### PR DESCRIPTION
# Description

Found in https://github.com/box/box-java-sdk/pull/910. In openapi we still have old `tracking_codes` schema in some places.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
