### PR TITLE
Added validation on vanity name on shared links. Added missing information about setting shared link on a weblink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ src/dev/openapi.json
 src/dev/scripts/objects/*
 migrate.js
 compiled
+
+#Intelij Idea
+*.iml
+.idea
+
+#OSX
+.DS_Store

--- a/content/paths/shared_links_files__put_files_id--add_shared_link.yml
+++ b/content/paths/shared_links_files__put_files_id--add_shared_link.yml
@@ -71,6 +71,7 @@ requestBody:
                   Custom URLs should not be used when sharing sensitive content
                   as vanity URLs are a lot easier to guess than regular shared
                   links.
+                minLength: 12
                 example: "my-shared-link"
 
               unshared_at:

--- a/content/paths/shared_links_files__put_files_id--update_shared_link.yml
+++ b/content/paths/shared_links_files__put_files_id--update_shared_link.yml
@@ -68,6 +68,7 @@ requestBody:
                   Custom URLs should not be used when sharing sensitive content
                   as vanity URLs are a lot easier to guess than regular shared
                   links.
+                minLength: 12
                 example: "my-shared-link"
 
               unshared_at:

--- a/content/paths/shared_links_folders__put_folders_id--add_shared_link.yml
+++ b/content/paths/shared_links_folders__put_folders_id--add_shared_link.yml
@@ -62,6 +62,18 @@ requestBody:
                   A password can only be set when `access` is set to `open`.
                 example: "do-not-use-this-password"
 
+              vanity_name:
+                type: string
+                description: |-
+                  Defines a custom vanity name to use in the shared link URL,
+                  for example `https://app.box.com/v/my-shared-link`.
+
+                  Custom URLs should not be used when sharing sensitive content
+                  as vanity URLs are a lot easier to guess than regular shared
+                  links.
+                minLength: 12
+                example: "my-shared-link"
+
               unshared_at:
                 type: string
                 format: date-time

--- a/content/paths/shared_links_folders__put_folders_id--update_shared_link.yml
+++ b/content/paths/shared_links_folders__put_folders_id--update_shared_link.yml
@@ -59,6 +59,18 @@ requestBody:
                   A password can only be set when `access` is set to `open`.
                 example: "do-not-use-this-password"
 
+              vanity_name:
+                type: string
+                description: |-
+                  Defines a custom vanity name to use in the shared link URL,
+                  for example `https://app.box.com/v/my-shared-link`.
+
+                  Custom URLs should not be used when sharing sensitive content
+                  as vanity URLs are a lot easier to guess than regular shared
+                  links.
+                minLength: 12
+                example: "my-shared-link"
+
               unshared_at:
                 type: string
                 format: date-time

--- a/content/paths/web_links__post_web_links.yml
+++ b/content/paths/web_links__post_web_links.yml
@@ -51,6 +51,64 @@ requestBody:
             description: |-
               Description of the web link.
 
+          shared_link:
+            description: |-
+              The settings for the shared link to update.
+
+            type: object
+            properties:
+              access:
+                type: string
+                description: |-
+                  The level of access for the shared link. This can be
+                  restricted to anyone with the link (`open`), only people
+                  within the company (`company`) and only those who
+                  have been invited to the folder (`collaborators`).
+
+                  If not set, this field defaults to the access level specified
+                  by the enterprise admin. To create a shared link with this
+                  default setting pass the `shared_link` object with
+                  no `access` field, for example `{ "shared_link": {} }`.
+
+                  The `company` access level is only available to paid
+                  accounts.
+                enum:
+                  - open
+                  - company
+                  - collaborators
+                example: "open"
+
+              password:
+                type: string
+                description: |-
+                  The password required to access the shared link. Set the
+                  password to `null` to remove it.
+
+                  A password can only be set when `access` is set to `open`.
+                example: "do-not-use-this-password"
+
+              vanity_name:
+                type: string
+                description: |-
+                  Defines a custom vanity name to use in the shared link URL,
+                  for example `https://app.box.com/v/my-shared-link`.
+
+                  Custom URLs should not be used when sharing sensitive content
+                  as vanity URLs are a lot easier to guess than regular shared
+                  links.
+                minLength: 12
+                example: "my-shared-link"
+
+              unshared_at:
+                type: string
+                format: date-time
+                example: "2012-12-12T10:53:43-08:00"
+                description: |-
+                  The timestamp at which this shared link will
+                  expire. This field can only be set by
+                  users with paid accounts. The value must be greater than the
+                  current date and time.
+
 responses:
   200:
     description:

--- a/content/paths/web_links__put_web_links_id.yml
+++ b/content/paths/web_links__put_web_links_id.yml
@@ -46,6 +46,64 @@ requestBody:
             description: |-
               A new description of the web link.
 
+          shared_link:
+            description: |-
+              The settings for the shared link to update.
+
+            type: object
+            properties:
+              access:
+                type: string
+                description: |-
+                  The level of access for the shared link. This can be
+                  restricted to anyone with the link (`open`), only people
+                  within the company (`company`) and only those who
+                  have been invited to the folder (`collaborators`).
+
+                  If not set, this field defaults to the access level specified
+                  by the enterprise admin. To create a shared link with this
+                  default setting pass the `shared_link` object with
+                  no `access` field, for example `{ "shared_link": {} }`.
+
+                  The `company` access level is only available to paid
+                  accounts.
+                enum:
+                  - open
+                  - company
+                  - collaborators
+                example: "open"
+
+              password:
+                type: string
+                description: |-
+                  The password required to access the shared link. Set the
+                  password to `null` to remove it.
+
+                  A password can only be set when `access` is set to `open`.
+                example: "do-not-use-this-password"
+
+              vanity_name:
+                type: string
+                description: |-
+                  Defines a custom vanity name to use in the shared link URL,
+                  for example `https://app.box.com/v/my-shared-link`.
+
+                  Custom URLs should not be used when sharing sensitive content
+                  as vanity URLs are a lot easier to guess than regular shared
+                  links.
+                minLength: 12
+                example: "my-shared-link"
+
+              unshared_at:
+                type: string
+                format: date-time
+                example: "2012-12-12T10:53:43-08:00"
+                description: |-
+                  The timestamp at which this shared link will
+                  expire. This field can only be set by
+                  users with paid accounts. The value must be greater than the
+                  current date and time.
+
 responses:
   200:
     description:


### PR DESCRIPTION
Part of the  SDK-1759 issue

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I have run `yarn lint` to make sure my changes pass all linters
- [X] I have pulled the latest changes from the upstream developer branch


