### PR TITLE
Eg 9092 add limit marker fields to get retention policies

### DIFF
--- a/content/attributes/marker_pagination_without_prev_marker.yml
+++ b/content/attributes/marker_pagination_without_prev_marker.yml
@@ -1,0 +1,22 @@
+---
+type: object
+
+description: |-
+  The part of an API response that describes marker
+  based pagination
+
+properties:
+  limit:
+    description: |-
+      The limit that was used for these entries. This will be the same as the
+      `limit` query parameter unless that value exceeded the maximum value
+      allowed. The maximum value varies by API.
+    example: 1000
+    type: integer
+    format: int64
+
+  next_marker:
+    description: |-
+      The marker for the start of the next page of results.
+    example: JV9IRGZmieiBasejOG9yDCRNgd2ymoZIbjsxbJMjIs3kioVii
+    type: string

--- a/content/attributes/marker_without_usemarker.yml
+++ b/content/attributes/marker_without_usemarker.yml
@@ -1,0 +1,11 @@
+---
+name: marker
+description: |-
+  Defines the position marker at which to begin returning results. This is
+  used when paginating using marker-based pagination.
+
+in: query
+required: false
+example: JV9IRGZmieiBasejOG9yDCRNgd2ymoZIbjsxbJMjIs3kioVii
+schema:
+  type: string

--- a/content/paths/retention_policies__get_retention_policies.yml
+++ b/content/paths/retention_policies__get_retention_policies.yml
@@ -43,6 +43,10 @@ parameters:
     schema:
       type: string
 
+  - $ref: '../attributes/fields.yml'
+  - $ref: '../attributes/limit.yml'
+  - $ref: '../attributes/marker_without_usemarker.yml'
+
 responses:
   200:
     description: |-

--- a/content/paths/retention_policy_assignments__get_retention_policies_id_assignments.yml
+++ b/content/paths/retention_policy_assignments__get_retention_policies_id_assignments.yml
@@ -26,7 +26,8 @@ parameters:
         - folder
         - enterprise
         - metadata_template
-  - $ref: '../attributes/marker.yml'
+  - $ref: '../attributes/fields.yml'
+  - $ref: '../attributes/marker_without_usemarker.yml'
   - $ref: '../attributes/limit.yml'
 
 responses:

--- a/content/responses/retention_policies.yml
+++ b/content/responses/retention_policies.yml
@@ -9,15 +9,10 @@ x-box-tag: retention_policies
 description: |-
   A list of retention policies
 
-properties:
-  total_count:
-    description: |-
-      The number of retention policies.
-    example: 156
-    type: integer
-    format: int64
-
-  entries:
-    type: array
-    items:
-      $ref: '#/components/schemas/RetentionPolicy'
+allOf:
+  - properties:
+      entries:
+        type: array
+        items:
+          $ref: '#/components/schemas/RetentionPolicy'
+  - $ref: "../attributes/marker_pagination_without_prev_marker.yml"

--- a/content/responses/retention_policy_assignments.yml
+++ b/content/responses/retention_policy_assignments.yml
@@ -10,9 +10,9 @@ description: |-
   A list of retention policy assignments
 
 allOf:
-  - $ref: "../attributes/marker_pagination.yml"
   - properties:
       entries:
         type: array
         items:
           $ref: '#/components/schemas/RetentionPolicyAssignment'
+  - $ref: "../attributes/marker_pagination_without_prev_marker.yml"


### PR DESCRIPTION
# Description

EG-9092: https://jira.inside-box.net/browse/EG-9092

-Added new marker attribute that doesn't have a line about needing usemarker to be true.
-Added limit, fields, and the new marker attribute to the query parameters of the get retention policies schema.
-Added fields and replaced the older marker attribute with the new one to the query parameters of the get retention policy assignment schemas.
-Added a new marker for pagination attribute that doesn't have a prev_marker entry and has a string as the next_marker type.
-Added the new marker for pagination to the Retention Policies response schema and removed total_count.
-Replaced the older marker with the new marker for pagination to the Retention Policy Assignments response schema and removed total_count.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
