### PR TITLE
Identify application-owned locks

### DIFF
--- a/content/attributes/lock.yml
+++ b/content/attributes/lock.yml
@@ -44,3 +44,18 @@ properties:
     example: true
     description: |-
       Whether or not the file can be downloaded while locked.
+
+  app_type:
+    type: string
+    description: |-
+      If the lock is managed by an application rather than a user, this
+      field identifies the type of the application that holds the lock.
+      This is an open enum and may be extended with additional values in
+      the future.
+    enum:
+      - gsuite
+      - office_wopi
+      - office_wopiplus
+      - other
+    example: office_wopiplus
+    nullable: true


### PR DESCRIPTION
# Description

Locks may be held by an application rather than an individual user. The
application is responsible for mediating access to the file. Identify
the owning application to enable clients to show different UI.

Re APIWG-266

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
