### PR TITLE
doc/uploads/post_files_content: Add missing `400` error response

### DIFF
--- a/content/paths/uploads__post_files_content.yml
+++ b/content/paths/uploads__post_files_content.yml
@@ -117,6 +117,19 @@ responses:
         schema:
           $ref: '#/components/schemas/Files'
 
+   400:
+    description: |-
+      Returns an error if some of the parameters are missing or
+      not valid.
+      * `bad_request` when a parameter is missing or incorrect.
+      * `item_name_too_long` when the folder name is too long.
+      * `item_name_invalid` when the folder name contains
+        non-valid characters.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
   409:
     description: |-
       Returns an error if the file already exists,

--- a/content/paths/uploads__post_files_content.yml
+++ b/content/paths/uploads__post_files_content.yml
@@ -117,7 +117,7 @@ responses:
         schema:
           $ref: '#/components/schemas/Files'
 
-   400:
+  400:
     description: |-
       Returns an error if some of the parameters are missing or
       not valid.


### PR DESCRIPTION
# Description

This PR adds the missing `400` error response for `uploads/post_files_content` referenced from https://github.com/box/box-openapi/blob/main/content/paths/folders__post_folders.yml as this exhibits the same behaviour as `folders/post_folders`, specifically regarding the naming of the object being created.

Feel free to add anything that may have not already been included, thank you.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
