### PR TITLE
doc/folders/delete_folders_id: Move `folder_not_empty` error from `409` to `400`

### DIFF
--- a/content/paths/folders__delete_folders_id.yml
+++ b/content/paths/folders__delete_folders_id.yml
@@ -36,14 +36,14 @@ responses:
     description: |-
       Returns an error if the user makes a bad request.
 
-      * `folder_not_empty`: Returned if the folder is not empty. Use the	
-        `recursive` query parameter to recursively delete the folder and	
+      * `folder_not_empty`: Returned if the folder is not empty. Use the
+        `recursive` query parameter to recursively delete the folder and
         its contents.
     content:
       application/json:
         schema:
           $ref: '#/components/schemas/ClientError'
-          
+
   403:
     description: |-
       Returns an error if the user does not have the required

--- a/content/paths/folders__delete_folders_id.yml
+++ b/content/paths/folders__delete_folders_id.yml
@@ -32,6 +32,18 @@ responses:
       Returns an empty response when the folder is successfully deleted
       or moved to the trash.
 
+  400:
+    description: |-
+      Returns an error if the user makes a bad request.
+
+      * `folder_not_empty`: Returned if the folder is not empty. Use the	
+        `recursive` query parameter to recursively delete the folder and	
+        its contents.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+          
   403:
     description: |-
       Returns an error if the user does not have the required
@@ -64,9 +76,6 @@ responses:
 
   409:
     description: |-
-      * `folder_not_empty`: Returned if the folder is not empty. Use the
-        `recursive` query parameter to recursively delete the folder and
-        its contents.
       * `operation_blocked_temporary`: Returned if the folder
         is locked due to another move, copy, delete or restore
         operation in progress.


### PR DESCRIPTION
# Description

This PR updates the `delete_folders_id` doc by moving the `folder_not_empty` error to be under `400`, from `409`.

## API res
```
HTTP/1.1 DELETE on https://api.box.com/2.0/folders/x responded 400 400 Bad Request ("{\"type\":\"error\",\"status\":400,\"code\":\"folder_not_empty\",\"help_url\":\"http:\\/\\/developers.box.com\\/docs\\/#errors\",\"message\":\"Cannot delete - folder not empty\",\"request_id\":\"x\"}")
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
