### PR TITLE
Ddoc 597 note email alias

### DIFF
--- a/content/paths/email_aliases__post_users_id_email_aliases.yml
+++ b/content/paths/email_aliases__post_users_id_email_aliases.yml
@@ -27,10 +27,12 @@ requestBody:
             example: "alias@example.com"
             description: |-
               The email address to add to the account as an alias.
+
               Note: The domain of the email alias needs to be registered
                to your enterprise.
-              See Domain Verification guide for steps to add a new domain:
-              https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
+              See [Domain Verification](
+                https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
+                ) guide for steps to add a new domain:
 
 responses:
   201:

--- a/content/paths/email_aliases__post_users_id_email_aliases.yml
+++ b/content/paths/email_aliases__post_users_id_email_aliases.yml
@@ -27,6 +27,10 @@ requestBody:
             example: "alias@example.com"
             description: |-
               The email address to add to the account as an alias.
+              Note: The domain of the email alias needs to be registered
+               to your enterprise.
+              See Domain Verification guide for steps to add a new domain:
+              https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
 
 responses:
   201:

--- a/content/paths/email_aliases__post_users_id_email_aliases.yml
+++ b/content/paths/email_aliases__post_users_id_email_aliases.yml
@@ -30,10 +30,9 @@ requestBody:
 
               Note: The domain of the email alias needs to be registered
                to your enterprise.
-
-              See [Domain Verification](
+              See the [domain verification guide](
                 https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
-                ) guide for steps to add a new domain:
+                ) for steps to add a new domain.
 
 responses:
   201:

--- a/content/paths/email_aliases__post_users_id_email_aliases.yml
+++ b/content/paths/email_aliases__post_users_id_email_aliases.yml
@@ -30,6 +30,7 @@ requestBody:
 
               Note: The domain of the email alias needs to be registered
                to your enterprise.
+
               See [Domain Verification](
                 https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
                 ) guide for steps to add a new domain:

--- a/content/paths/email_aliases__post_users_id_email_aliases.yml
+++ b/content/paths/email_aliases__post_users_id_email_aliases.yml
@@ -30,7 +30,6 @@ requestBody:
 
               Note: The domain of the email alias needs to be registered
                to your enterprise.
-
               See [Domain Verification](
                 https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification
                 ) guide for steps to add a new domain:


### PR DESCRIPTION
DDOC-597:  Add a note about domain restriction on email_aliases endpoint

> Note: The domain of the email alias needs to be registered to your enterprise. See this for steps to add a new domain: https://support.box.com/hc/en-us/articles/4408619650579-Domain-Verification

Re `DDOC-597` (`Jira` ticket)


