### PR TITLE
add `version_number` to `file_version`

### DIFF
--- a/content/responses/file_version--base.yml
+++ b/content/responses/file_version--base.yml
@@ -9,6 +9,7 @@ x-box-variants:
   - base
   - mini
   - standard
+  - full
 x-box-variant: base
 
 description: |-

--- a/content/responses/file_version--full.yml
+++ b/content/responses/file_version--full.yml
@@ -1,0 +1,19 @@
+---
+title: File version (Full)
+
+type: object
+
+x-box-resource-id: file_version--full
+x-box-variant: full
+
+description: |-
+  A full representation of a file version, as can be returned from any
+  file version API endpoints by default
+
+allOf:
+  - $ref: '#/components/schemas/FileVersion'
+  - properties:
+      version_number:
+        type: string
+        example: "1"
+        description: The version number of this file version

--- a/content/schemas.yml
+++ b/content/schemas.yml
@@ -142,6 +142,9 @@ FileVersion--Mini:
 FileVersion--Base:
   "$ref": "./responses/file_version--base.yml"
 
+FileVersion--Full:
+  "$ref": "./responses/file_version--full.yml"
+
 FileVersions:
   "$ref": "./responses/file_versions.yml"
 


### PR DESCRIPTION
# Description

This field is already supported in the java-sdk, and now windows-sdk support has also been added https://github.com/box/box-windows-sdk-v2/pull/820, but it was missing from open-api specs. I have also extracted fileversion--full, as this field must be required by the `fields` parameter.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
