### PR TITLE
feat: Require non-nullable fields [DDOC-607]

### DIFF
--- a/content/attributes/file_permissions.yml
+++ b/content/attributes/file_permissions.yml
@@ -4,6 +4,14 @@ type: object
 description:
   The permissions that the authenticated user has for a file.
 
+required:
+  - can_annotate
+  - can_comment
+  - can_preview
+  - can_upload
+  - can_view_annotations_all
+  - can_view_annotations_self
+
 allOf:
   - $ref: "./permissions.yml"
   - properties:

--- a/content/attributes/folder_permissions.yml
+++ b/content/attributes/folder_permissions.yml
@@ -4,6 +4,9 @@ type: object
 description:
   The permissions that the authenticated user has for a folder.
 
+required:
+  - can_upload
+
 allOf:
   - $ref: "./permissions.yml"
   - properties:

--- a/content/attributes/path_collection.yml
+++ b/content/attributes/path_collection.yml
@@ -6,6 +6,10 @@ description: |-
 
 type: object
 
+required:
+  - total_count
+  - entries
+
 properties:
   total_count:
     description: |-

--- a/content/attributes/path_collection_trash.yml
+++ b/content/attributes/path_collection_trash.yml
@@ -6,6 +6,10 @@ description: |-
 
 type: object
 
+required:
+  - total_count
+  - entries
+
 properties:
   total_count:
     description: |-

--- a/content/attributes/permissions.yml
+++ b/content/attributes/permissions.yml
@@ -4,6 +4,14 @@ type: object
 description:
   The permissions that the authenticated user has for an item.
 
+required:
+  - can_delete
+  - can_download
+  - can_invite_collaborator
+  - can_rename
+  - can_set_share_access
+  - can_share
+
 properties:
   can_delete:
     type: boolean

--- a/content/attributes/shared_link.yml
+++ b/content/attributes/shared_link.yml
@@ -10,6 +10,15 @@ description: |-
 
 type: object
 
+required:
+  - url
+  - accessed
+  - effective_access
+  - effective_permission
+  - is_password_enabled
+  - download_count
+  - preview_count
+
 properties:
   url:
     type: string
@@ -116,6 +125,10 @@ properties:
     type: object
     description: |-
       Defines if this link allows a user to preview and download an item.
+    required:
+      - can_download
+      - can_preview
+      - can_edit
     properties:
       can_download:
         type: boolean

--- a/content/responses/classification_template.yml
+++ b/content/responses/classification_template.yml
@@ -11,6 +11,9 @@ description: |-
   A metadata template that holds the security classifications
   defined by an enterprise.
 
+required:
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/file--base.yml
+++ b/content/responses/file--base.yml
@@ -18,6 +18,10 @@ description: |-
   amount of fields returned when using the `fields` query
   parameter.
 
+required:
+  - id
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/file--full.yml
+++ b/content/responses/file--full.yml
@@ -10,6 +10,13 @@ description: |-
   A full representation of a file, as can be returned from any
   file API endpoints by default
 
+required:
+  - permissions
+  - tags
+  - allowed_invitee_roles
+  - is_externally_owned
+  - has_collaborations
+
 allOf:
   - $ref: '#/components/schemas/File'
   - properties:

--- a/content/responses/file--mini.yml
+++ b/content/responses/file--mini.yml
@@ -10,6 +10,10 @@ description: |-
   A mini representation of a file, used when
   nested under another resource.
 
+required:
+  - sequence_id
+  - sha1
+
 allOf:
   - $ref: '#/components/schemas/File--Base'
   - properties:

--- a/content/responses/file.yml
+++ b/content/responses/file.yml
@@ -10,6 +10,16 @@ description: |-
   A standard representation of a file, as returned from any
   file API endpoints by default
 
+required:
+  - description
+  - size
+  - path_collection
+  - created_at
+  - modified_at
+  - modified_by
+  - owned_by
+  - item_status
+
 allOf:
   - $ref: '#/components/schemas/File--Mini'
   - properties:

--- a/content/responses/file_request.yml
+++ b/content/responses/file_request.yml
@@ -10,6 +10,12 @@ description: |-
   A standard representation of a file request, as returned
   from any file request API endpoints by default.
 
+
+required:
+  - folder
+  - created_at
+  - updated_at
+
 properties:
   id:
     type: string

--- a/content/responses/file_version--base.yml
+++ b/content/responses/file_version--base.yml
@@ -17,6 +17,10 @@ description: |-
   amount of fields returned when using the `fields` query
   parameter.
 
+required:
+  - id
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/folder--base.yml
+++ b/content/responses/folder--base.yml
@@ -18,6 +18,10 @@ description: |-
   amount of fields returned when using the `fields` query
   parameter.
 
+required:
+  - id
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/folder--full.yml
+++ b/content/responses/folder--full.yml
@@ -10,6 +10,17 @@ description: |-
   A full representation of a folder, as can be returned from any
   folder API endpoints by default
 
+required:
+  - has_collaborations
+  - permissions
+  - tags
+  - can_non_owners_invite
+  - is_externally_owned
+  - is_collaboration_restricted_to_enterprise
+  - allowed_shared_link_access_levels
+  - allowed_invitee_roles
+  - watermark_info
+
 allOf:
   - $ref: '#/components/schemas/Folder'
   - properties:

--- a/content/responses/folder.yml
+++ b/content/responses/folder.yml
@@ -10,6 +10,15 @@ description: |-
   A standard representation of a folder, as returned from any
   folder API endpoints by default
 
+required:
+  - size
+  - path_collection
+  - created_by
+  - modified_by
+  - owned_by
+  - item_status
+  - item_collection
+
 allOf:
   - $ref: '#/components/schemas/Folder--Mini'
   - properties:

--- a/content/responses/folder_lock.yml
+++ b/content/responses/folder_lock.yml
@@ -43,6 +43,9 @@ properties:
       The operations that have been locked. Currently the `move`
       and `delete` operations cannot be locked separately, and both need to be
       set to `true`.
+    required:
+      - move
+      - delete
     properties:
       move:
         type: boolean

--- a/content/responses/metadata_query_index.yml
+++ b/content/responses/metadata_query_index.yml
@@ -10,6 +10,10 @@ x-box-tag: search
 description: |-
   A metadata query index
 
+required:
+  - type
+  - status
+
 properties:
   id:
     type: string

--- a/content/responses/metadata_template.yml
+++ b/content/responses/metadata_template.yml
@@ -10,6 +10,9 @@ x-box-tag: metadata_templates
 description: |-
   A template for metadata that can be applied to files and folders
 
+required:
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/retention_policy--base.yml
+++ b/content/responses/retention_policy--base.yml
@@ -16,6 +16,10 @@ description: |-
   amount of fields returned when using the `fields` query
   parameter.
 
+required:
+  - id
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/trash_file.yml
+++ b/content/responses/trash_file.yml
@@ -9,6 +9,20 @@ x-box-tag: trashed_files
 description: |-
   Represents a trashed file.
 
+required:
+  - id
+  - type
+  - sequence_id
+  - sha1
+  - description
+  - size
+  - path_collection
+  - created_at
+  - modified_at
+  - modified_by
+  - owned_by
+  - item_status
+
 properties:
   id:
     type: string

--- a/content/responses/trash_file_restored.yml
+++ b/content/responses/trash_file_restored.yml
@@ -9,6 +9,20 @@ x-box-tag: trashed_files
 description: |-
   Represents a file restored from the trash.
 
+required:
+  - id
+  - type
+  - sequence_id
+  - sha1
+  - description
+  - size
+  - path_collection
+  - created_at
+  - modified_at
+  - modified_by
+  - owned_by
+  - item_status
+
 properties:
   id:
     type: string

--- a/content/responses/trash_folder.yml
+++ b/content/responses/trash_folder.yml
@@ -9,6 +9,18 @@ x-box-tag: trashed_folders
 description: |-
   Represents a trashed folder.
 
+required:
+  - id
+  - type
+  - name
+  - description
+  - size
+  - path_collection
+  - created_by
+  - modified_by
+  - owned_by
+  - item_status
+
 properties:
   id:
     type: string

--- a/content/responses/trash_web_link_restored.yml
+++ b/content/responses/trash_web_link_restored.yml
@@ -9,6 +9,10 @@ x-box-tag: trashed_web_links
 description: |-
   Represents a web link restored from the trash.
 
+required:
+  - sequence_id
+  - path_collection
+
 properties:
   type:
     type: string

--- a/content/responses/user--base.yml
+++ b/content/responses/user--base.yml
@@ -16,6 +16,9 @@ description: |-
   A mini representation of a user, used when
   nested within another resource.
 
+required:
+  - type
+
 properties:
   id:
     type: string

--- a/content/responses/user--mini.yml
+++ b/content/responses/user--mini.yml
@@ -10,6 +10,10 @@ description: |-
   A mini representation of a user, as can be returned when nested within other
   resources.
 
+required:
+  - name
+  - login
+
 allOf:
   - $ref: '#/components/schemas/User--Base'
   - properties:

--- a/content/responses/web_link--base.yml
+++ b/content/responses/web_link--base.yml
@@ -18,6 +18,10 @@ description: |-
   Web link objects are treated similarly to file objects,
   they will also support most actions that apply to regular files.
 
+required:
+  - id
+  - type
+
 properties:
   id:
     type: string

--- a/content/schemas/event_source.yml
+++ b/content/schemas/event_source.yml
@@ -9,6 +9,11 @@ description: |-
   The source file or folder that triggered an event in
   the event stream.
 
+required:
+  - item_type
+  - item_id
+  - item_name
+
 properties:
   item_type:
     type: string

--- a/docs/boxers.md
+++ b/docs/boxers.md
@@ -43,7 +43,7 @@ When working on the API specification we recommend the following best practices:
 * **Draft Pull Requests:** When working on a design change that has not yet been
   approved, we high recommend creating a **draft Pull Request**, as it won't be
   accidentally merged before the change is ready.
- 
+
 ---
 
 [**Next:** The OpenAPI structure and custom attributes](./structure.md)


### PR DESCRIPTION
# Description

This PR will add a **required** Array with properties which are already marked as non-nullable.
This way TS types generated using [openapi-typescript](https://github.com/drwpow/openapi-typescript)
[related issue regarding required types](https://github.com/drwpow/openapi-typescript/issues/758)

# Fixes 
https://jira.inside-box.net/browse/DDOC-607

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

