### PR TITLE
DDOC-485: Add params and endpoints for retention policies 

### DIFF
--- a/content/paths.yml
+++ b/content/paths.yml
@@ -593,6 +593,8 @@
 "/retention_policy_assignments/{retention_policy_assignment_id}":
   get:
     "$ref": "./paths/retention_policy_assignments__get_retention_policy_assignments_id.yml"
+  delete:
+    "$ref": "./paths/retention_policy_assignments__delete_retention_policy_assignments_id.yml"
 
 "/retention_policy_assignments/{retention_policy_assignment_id}/files_under_retention":
   get:

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -76,8 +76,23 @@ requestBody:
             type: string
             example: modifiable
             description: |-
-              Specifies if a policy can or
-              cannot be modified.
+              Specifies the retention type:
+
+              * `modifiable`: You can modify the retention policy. For example,
+              you can add or remove folders, shorten or lengthen
+              the policy duration, or delete the policy.
+              Use this type if your retention policy
+              is not related to any regulatory purposes.
+
+              * `non-modifiable`: You can modify the retention policy
+              only in a limited way: add a folder, lengthen the duration,
+              retire the policy, change the disposition action
+              or notification settings.You cannot perform other actions,
+              such as deleting the policy or shortening its duration.
+              Use this type when you want to ensure
+              compliance with regulatory retention policies
+              (such as SEC Rule 17a-4(f).
+
             enum:
               - modifiable
               - non-modifiable

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -87,11 +87,10 @@ requestBody:
               * `non-modifiable`: You can modify the retention policy
               only in a limited way: add a folder, lengthen the duration,
               retire the policy, change the disposition action
-              or notification settings.You cannot perform other actions,
+              or notification settings. You cannot perform other actions,
               such as deleting the policy or shortening its duration.
               Use this type when you want to ensure
-              compliance with regulatory retention policies
-              (such as SEC Rule 17a-4(f).
+              compliance with regulatory retention policies.
 
             enum:
               - modifiable

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -80,7 +80,7 @@ requestBody:
 
               * `modifiable`: You can modify the retention policy. For example,
               you can add or remove folders, shorten or lengthen
-              the policy duration, or delete the policy.
+              the policy duration, or delete the assignment.
               Use this type if your retention policy
               is not related to any regulatory purposes.
 
@@ -88,8 +88,8 @@ requestBody:
               only in a limited way: add a folder, lengthen the duration,
               retire the policy, change the disposition action
               or notification settings. You cannot perform other actions,
-              such as deleting the policy or shortening its duration.
-              Use this type when you want to ensure
+              such as deleting the assignment or shortening the
+              policy duration. Use this type to ensure
               compliance with regulatory retention policies.
             enum:
               - modifiable

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -66,7 +66,7 @@ requestBody:
             minimum: 1
             description: |-
               The length of the retention policy. This value
-              specifies the duration in days when the retention
+              specifies the duration in days that the retention
               policy will be active for after being assigned to
               content.  If the policy has a `policy_type` of
               `indefinite`, the `retention_length` will also be

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -91,7 +91,6 @@ requestBody:
               such as deleting the policy or shortening its duration.
               Use this type when you want to ensure
               compliance with regulatory retention policies.
-
             enum:
               - modifiable
               - non-modifiable

--- a/content/paths/retention_policies__post_retention_policies.yml
+++ b/content/paths/retention_policies__post_retention_policies.yml
@@ -50,12 +50,11 @@ requestBody:
             example: permanently_delete
             description: |-
               The disposition action of the retention policy.
-              This action can be `permanently_delete`, which
-              will cause the content retained by the policy
-              to be permanently deleted, or `remove_retention`,
-              which will lift the retention policy from the content,
-              allowing it to be deleted by users,
-              once the retention policy has expired.
+              `permanently_delete` deletes the content
+              retained by the policy permanently.
+              `remove_retention` lifts retention policy
+              from the content, allowing it to be deleted
+              by users once the retention policy has expired.
             enum:
               - permanently_delete
               - remove_retention
@@ -66,12 +65,22 @@ requestBody:
             example: "365"
             minimum: 1
             description: |-
-              The length of the retention policy. This length
-              specifies the duration in days that the retention
+              The length of the retention policy. This value
+              specifies the duration in days when the retention
               policy will be active for after being assigned to
-              content.  If the policy has A `policy_type` of
+              content.  If the policy has a `policy_type` of
               `indefinite`, the `retention_length` will also be
               `indefinite`.
+
+          retention_type:
+            type: string
+            example: modifiable
+            description: |-
+              Specifies if a policy can or
+              cannot be modified.
+            enum:
+              - modifiable
+              - non-modifiable
 
           can_owner_extend_retention:
             type: boolean
@@ -91,10 +100,8 @@ requestBody:
             type: array
             items:
               type: object
-
               description: |-
                 A user that is notified of an event.
-
               properties:
                 type:
                   description: The type of item to notify

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -47,6 +47,7 @@ requestBody:
 
           retention_type:
             type: string
+            example: non-modifiable
             description: |-
               Specifies the retention type:
 

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -47,7 +47,6 @@ requestBody:
 
           retention_type:
             type: string
-            example: non-modifiable
             description: |-
               Specifies the retention type:
 
@@ -65,6 +64,12 @@ requestBody:
               Use this type when you want to ensure
               compliance with regulatory retention policies.
 
+              Note
+              When updating a retention policy, you can use
+              `non-modifiable` type only. You can convert a
+              `modifiable` policy to `non-modifiable`, but
+              not the other way around.
+            example: non-modifiable
             enum:
               - non-modifiable
 

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -59,11 +59,10 @@ requestBody:
               * `non-modifiable`: You can modify the retention policy
               only in a limited way: add a folder, lengthen the duration,
               retire the policy, change the disposition action
-              or notification settings.You cannot perform other actions,
+              or notification settings. You cannot perform other actions,
               such as deleting the policy or shortening its duration.
               Use this type when you want to ensure
-              compliance with regulatory retention policies
-              (such as SEC Rule 17a-4(f).
+              compliance with regulatory retention policies.
 
             enum:
               - non-modifiable

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -48,11 +48,25 @@ requestBody:
           retention_type:
             type: string
             description: |-
-             Specifies if a policy can or
-             cannot be modified.
+              Specifies the retention type:
+
+              * `modifiable`: You can modify the retention policy. For example,
+              you can add or remove folders, shorten or lengthen
+              the policy duration, or delete the policy.
+              Use this type if your retention policy
+              is not related to any regulatory purposes.
+
+              * `non-modifiable`: You can modify the retention policy
+              only in a limited way: add a folder, lengthen the duration,
+              retire the policy, change the disposition action
+              or notification settings.You cannot perform other actions,
+              such as deleting the policy or shortening its duration.
+              Use this type when you want to ensure
+              compliance with regulatory retention policies
+              (such as SEC Rule 17a-4(f).
+
             enum:
               - non-modifiable
-            example: non-modifiable
 
           retention_length:
             type: string

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -53,15 +53,15 @@ requestBody:
 
               * `modifiable`: You can modify the retention policy. For example,
               you can add or remove folders, shorten or lengthen
-              the policy duration, or delete the policy.
+              the policy duration, or delete the assignment.
               Use this type if your retention policy
               is not related to any regulatory purposes.
               * `non-modifiable`: You can modify the retention policy
               only in a limited way: add a folder, lengthen the duration,
               retire the policy, change the disposition action
               or notification settings. You cannot perform other actions,
-              such as deleting the policy or shortening its duration.
-              Use this type when you want to ensure
+              such as deleting the assignment or shortening the
+              policy duration. Use this type to ensure
               compliance with regulatory retention policies.
 
               When updating a retention policy, you can use

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -51,9 +51,8 @@ requestBody:
              Specifies if a policy can or
              cannot be modified.
             enum:
-              - modifiable
               - non-modifiable
-            example: modifiable
+            example: non-modifiable
 
           retention_length:
             type: string
@@ -61,7 +60,7 @@ requestBody:
             example: "365"
             description: |-
               The length of the retention policy. This value
-              specifies the duration in days when the retention
+              specifies the duration in days that the retention
               policy will be active for after being assigned to
               content.  If the policy has a `policy_type` of
               `indefinite`, the `retention_length` will also be

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -47,6 +47,7 @@ requestBody:
 
           retention_type:
             type: string
+            example: non-modifiable
             description: |-
               Specifies the retention type:
 
@@ -55,7 +56,6 @@ requestBody:
               the policy duration, or delete the policy.
               Use this type if your retention policy
               is not related to any regulatory purposes.
-
               * `non-modifiable`: You can modify the retention policy
               only in a limited way: add a folder, lengthen the duration,
               retire the policy, change the disposition action
@@ -64,14 +64,10 @@ requestBody:
               Use this type when you want to ensure
               compliance with regulatory retention policies.
 
-              Note
               When updating a retention policy, you can use
               `non-modifiable` type only. You can convert a
               `modifiable` policy to `non-modifiable`, but
               not the other way around.
-            example: non-modifiable
-            enum:
-              - non-modifiable
 
           retention_length:
             type: string
@@ -93,8 +89,6 @@ requestBody:
 
               If not retiring a policy, do not include this parameter
               or set it to `null`.
-            enum:
-              - retired
 
 responses:
   200:

--- a/content/paths/retention_policies__put_retention_policies_id.yml
+++ b/content/paths/retention_policies__put_retention_policies_id.yml
@@ -36,15 +36,36 @@ requestBody:
             example: permanently_delete
             description: |-
               The disposition action of the retention policy.
-              This action can be `permanently_delete`, which
-              will cause the content retained by the policy
-              to be permanently deleted, or `remove_retention`,
-              which will lift the retention policy from the content,
-              allowing it to be deleted by users,
-              once the retention policy has expired.
+              `permanently_delete` deletes the content
+              retained by the policy permanently.
+              `remove_retention` lifts retention policy
+              from the content, allowing it to be deleted
+              by users once the retention policy has expired.
             enum:
               - permanently_delete
               - remove_retention
+
+          retention_type:
+            type: string
+            description: |-
+             Specifies if a policy can or
+             cannot be modified.
+            enum:
+              - modifiable
+              - non-modifiable
+            example: modifiable
+
+          retention_length:
+            type: string
+            format: int32
+            example: "365"
+            description: |-
+              The length of the retention policy. This value
+              specifies the duration in days when the retention
+              policy will be active for after being assigned to
+              content.  If the policy has a `policy_type` of
+              `indefinite`, the `retention_length` will also be
+              `indefinite`.
 
           status:
             type: string
@@ -75,7 +96,19 @@ responses:
       application/json:
         schema:
           $ref: '#/components/schemas/ClientError'
-
+  403:
+    description: |-
+      Returns an error when a user wants to
+      shorten the duration of a
+      non-modifiable policy, or to convert
+      a non-modifiable policy to
+      a modifiable one.
+      Note: Lengthening policy duration
+      is allowed.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
   409:
     description: |-
       Returns an error if a retention policy with the given name already exists

--- a/content/paths/retention_policy_assignments__delete_retention_policy_assignments_id.yml
+++ b/content/paths/retention_policy_assignments__delete_retention_policy_assignments_id.yml
@@ -1,0 +1,47 @@
+---
+operationId: delete_retention_policy_assignments_id
+
+summary: Remove retention policy assignment
+
+tags:
+  - Retention policy assignments
+
+x-box-tag: retention_policy_assignments
+
+description: |-
+  Removes a retention policy assignment
+  applied to content.
+
+parameters:
+  - $ref: '../attributes/retention_policy_assignment_id.yml'
+
+responses:
+  204:
+    description: |-
+      Returns an empty response when the policy assignment
+      is successfully deleted.
+
+  403:
+    description: |-
+      Returns an error when the assignment relates to
+      a retention policy that cannot be modified.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+  404:
+    description: |-
+      Returns an error when the retention policy
+      assignment does not exist.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'
+
+  default:
+    description: |-
+      An unexpected client error.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ClientError'

--- a/content/paths/retention_policy_assignments__post_retention_policy_assignments.yml
+++ b/content/paths/retention_policy_assignments__post_retention_policy_assignments.yml
@@ -46,7 +46,6 @@ requestBody:
                 type: string
                 description: |-
                   The ID of item to assign the policy to.
-
                   Set to `null` or omit when `type` is set to
                   `enterprise`.
                 example: "6564564"

--- a/content/responses/retention_policy--mini.yml
+++ b/content/responses/retention_policy--mini.yml
@@ -25,7 +25,7 @@ allOf:
         minimum: 1
         description: |-
           The length of the retention policy. This value
-          specifies the duration in days when the retention
+          specifies the duration in days that the retention
           policy will be active for after being assigned to
           content.  If the policy has a `policy_type` of
           `indefinite`, the `retention_length` will also be

--- a/content/responses/retention_policy--mini.yml
+++ b/content/responses/retention_policy--mini.yml
@@ -24,10 +24,10 @@ allOf:
         example: "365"
         minimum: 1
         description: |-
-          The length of the retention policy. This length
-          specifies the duration in days that the retention
+          The length of the retention policy. This value
+          specifies the duration in days when the retention
           policy will be active for after being assigned to
-          content.  If the policy has A `policy_type` of
+          content.  If the policy has a `policy_type` of
           `indefinite`, the `retention_length` will also be
           `indefinite`.
 

--- a/content/responses/retention_policy.yml
+++ b/content/responses/retention_policy.yml
@@ -45,7 +45,7 @@ allOf:
 
           * `modifiable`: You can modify the retention policy. For example,
            you can add or remove folders, shorten or lengthen
-           the policy duration, or delete the policy.
+           the policy duration, or delete the assignment.
            Use this type if your retention policy
            is not related to any regulatory purposes.
 
@@ -53,8 +53,8 @@ allOf:
            only in a limited way: add a folder, lengthen the duration,
            retire the policy, change the disposition action
            or notification settings. You cannot perform other actions,
-           such as deleting the policy or shortening its duration.
-           Use this type when you want to ensure
+           such as deleting the assignment or shortening the
+           policy duration. Use this type to ensure
            compliance with regulatory retention policies.
         enum:
           - modifiable

--- a/content/responses/retention_policy.yml
+++ b/content/responses/retention_policy.yml
@@ -52,11 +52,10 @@ allOf:
           * `non-modifiable`: You can modify the retention policy
            only in a limited way: add a folder, lengthen the duration,
            retire the policy, change the disposition action
-           or notification settings.You cannot perform other actions,
+           or notification settings. You cannot perform other actions,
            such as deleting the policy or shortening its duration.
            Use this type when you want to ensure
-           compliance with regulatory retention policies
-           (such as SEC Rule 17a-4(f).
+           compliance with regulatory retention policies.
         enum:
           - modifiable
           - non-modifiable

--- a/content/responses/retention_policy.yml
+++ b/content/responses/retention_policy.yml
@@ -37,6 +37,16 @@ allOf:
           - finite
           - indefinite
 
+      retention_type:
+        type: string
+        example: modifiable
+        description: |-
+          Specifies if a policy can or
+          cannot be modified.
+        enum:
+          - modifiable
+          - non-modifiable
+
       status:
         type: string
         example: active

--- a/content/responses/retention_policy.yml
+++ b/content/responses/retention_policy.yml
@@ -41,8 +41,22 @@ allOf:
         type: string
         example: modifiable
         description: |-
-          Specifies if a policy can or
-          cannot be modified.
+          Specifies the retention type:
+
+          * `modifiable`: You can modify the retention policy. For example,
+           you can add or remove folders, shorten or lengthen
+           the policy duration, or delete the policy.
+           Use this type if your retention policy
+           is not related to any regulatory purposes.
+
+          * `non-modifiable`: You can modify the retention policy
+           only in a limited way: add a folder, lengthen the duration,
+           retire the policy, change the disposition action
+           or notification settings.You cannot perform other actions,
+           such as deleting the policy or shortening its duration.
+           Use this type when you want to ensure
+           compliance with regulatory retention policies
+           (such as SEC Rule 17a-4(f).
         enum:
           - modifiable
           - non-modifiable

--- a/content/responses/retention_policy.yml
+++ b/content/responses/retention_policy.yml
@@ -39,7 +39,7 @@ allOf:
 
       retention_type:
         type: string
-        example: modifiable
+        example: non-modifiable
         description: |-
           Specifies the retention type:
 


### PR DESCRIPTION
# Description

New docs:

Add DELETE endpoint to retention policy assignments docs: https://staging.developer.box.com/reference/delete-retention-policy-assignments-id/

Updates: 

- Added `retention_type` parameter to POST request for retention policies: https://staging.developer.box.com/reference/post-retention-policies/
- Added `retention_type` and `retention_length` parameters to PUT request for retention policies: https://staging.developer.box.com/reference/put-retention-policies-id/
- Added `retention_type` to the standard response. Mini and base responses stay the same. 
https://staging.developer.box.com/reference/resources/retention-policy/


Fixes DDOC-485
