### PR TITLE
DDOC-666: Fix link in error response

### DIFF
--- a/content/errors/client_error.yml
+++ b/content/errors/client_error.yml
@@ -69,7 +69,7 @@ properties:
   help_url:
     description: |-
       A URL that links to more information about why this error occurred.
-    example: http://developers.box.com/docs/#errors
+    example: https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/
     type: string
     nullable: false
 

--- a/content/errors/client_error.yml
+++ b/content/errors/client_error.yml
@@ -69,7 +69,8 @@ properties:
   help_url:
     description: |-
       A URL that links to more information about why this error occurred.
-    example: https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/
+    example: |-
+      https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/
     type: string
     nullable: false
 


### PR DESCRIPTION
# Description

Fix link in error response (https://developer.box.com/reference/resources/client-error/)

Fixes DDOC-666

