### PR TITLE
Add login-required parameter to dev docs

### DIFF
--- a/content/schemas/sign_request_create_signer.yml
+++ b/content/schemas/sign_request_create_signer.yml
@@ -71,6 +71,16 @@ properties:
     example: 'https://declined-example.com'
     nullable: true
 
+  login_required:
+    type: boolean
+    description: |-
+      If set to true, signer will need to login to a Box account
+      before signing the request. If the signer does not have
+      an existing account, they will have an option to create
+      a free Box account.
+    example: true
+    nullable: true
+
   verification_phone_number:
     type: string
     description: |-


### PR DESCRIPTION
Add login-required parameter to guides and open API specs in developer documentation.

#[DDOC-677](https://jira.inside-box.net/browse/DDOC-677)