### PR TITLE
DDOC-710: Change variant from Mini to Base

### DIFF
--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -86,7 +86,7 @@ properties:
   source_files:
     type: array
     items:
-      $ref: '#/components/schemas/File--Mini'
+      $ref: '#/components/schemas/File--Base'
     description: >-
       List of files to create a signing document from. This is
       currently limited to one file. Only the ID and type fields are required


### PR DESCRIPTION
# Description
Changed the `File` resource variant from mini to base.
Preview: https://staging.developer.box.com/reference/post-sign-requests/

Fixes DDOC-710