### PR TITLE
DDOC-692: Added missing parameters to sign request

### DIFF
--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -12,9 +12,14 @@ required:
   - parent_folder
 
 properties:
+  name:
+    type: string
+    example: name
+    description: Name of the sign request
+
   is_document_preparation_needed:
     type: boolean
-    description: >-
+    description: |-
       If set, the sender receives a `prepare_url` in the response for completed
       document preparation via UI.
     example: true

--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -142,7 +142,7 @@ properties:
   signature_color:
     type: string
     example: blue
-    description: Force a specific color for the signature (blue, black, or red)
+    description: Specific signature color.
     enum:
       - blue
       - black

--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -14,8 +14,8 @@ required:
 properties:
   name:
     type: string
-    example: name
-    description: Name of the sign request
+    example: document sign request
+    description: The name of the sign request.
 
   is_document_preparation_needed:
     type: boolean
@@ -58,6 +58,7 @@ properties:
     description: >-
       Subject of sign request email. This is cleaned by sign
       request. If this field is not passed, a default subject will be used.
+
 
   email_message:
     type: string
@@ -137,3 +138,13 @@ properties:
       prior to viewing the document. A `verification_phone_number` must
       be specified for a signer for this setting to apply.
     example: true
+
+  signature_color:
+    type: string
+    example: blue
+    description: Force a specific color for the signature (blue, black, or red)
+    enum:
+      - blue
+      - black
+      - red
+    nullable: true

--- a/content/responses/sign_request.yml
+++ b/content/responses/sign_request.yml
@@ -28,7 +28,7 @@ allOf:
         type: string
         example: blue
         description: |-
-         Add a specific color for the signature.
+         Specific signature color.
         enum:
           - blue
           - black

--- a/content/responses/sign_request.yml
+++ b/content/responses/sign_request.yml
@@ -12,7 +12,7 @@ description: |-
 allOf:
   - $ref: '#/components/schemas/SignRequestCreateRequest'
   - properties:
-      'type':
+      type:
         type: string
         example: sign-request
         enum: [sign-request]
@@ -23,6 +23,16 @@ allOf:
         items:
           $ref: '#/components/schemas/SignRequestSigner'
         description: Array of signers for the sign request
+
+      signature_color:
+        type: string
+        example: blue
+        description: |-
+         Add a specific color for the signature.
+        enum:
+          - blue
+          - black
+          - red
 
       id:
         type: string


### PR DESCRIPTION
# Description

Add missing parameters to the sign request response / request objects:
`signature_color`
`name`

Staging preview: 
https://staging.developer.box.com/reference/resources/sign-request/
https://staging.developer.box.com/reference/post-sign-requests/

Fixes: DDOC-692
