### PR TITLE
days_valid minimum value is 0

### DIFF
--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -120,7 +120,7 @@ properties:
     description: >-
       Number of days after which this request will automatically
       expire if not completed
-    minimum: 1
+    minimum: 0
     maximum: 730
     example: 2
 


### PR DESCRIPTION
Minimum value for sign request parameter `days_valid` has range of 0-730.
Changed the min. value.

#[DDOC-660](https://jira.inside-box.net/browse/DDOC-660)