### PR TITLE
Add value 'attachment' to signer input schema

### DIFF
--- a/content/schemas/sign_request_signer_input.yml
+++ b/content/schemas/sign_request_signer_input.yml
@@ -37,6 +37,7 @@ allOf:
           - text
           - date
           - checkbox
+          - attachment
         description: Content type of input
         example: 'signature'
       page_index:


### PR DESCRIPTION
Add value 'attachment' to signer input schema - [[inputs].content_type](https://developer.box.com/reference/resources/sign-request/#param-signers-inputs-content_type)

Solves [DDOC-711](https://jira.inside-box.net/browse/DDOC-711)