### PR TITLE
DDOC-757-DDOC-769: Fix field description and parameter 

### DIFF
--- a/content/paths/files__get_files_id.yml
+++ b/content/paths/files__get_files_id.yml
@@ -41,7 +41,7 @@ parameters:
 
     example: "[pdf]"
     in: header
-    required: true
+    required: false
     schema:
       type: string
       nullable: true

--- a/content/responses/retention_policy_assignment.yml
+++ b/content/responses/retention_policy_assignment.yml
@@ -99,4 +99,6 @@ properties:
     type: string
     description: |-
       The date the retention policy assignment begins.
+      If the `assigned_to` type is `metadata_template`,
+      this field can be a date field's metadata attribute key id.
     example: "upload_date"


### PR DESCRIPTION
# Description

DDOC-757:  make `x-rep-hints` param optional
DDOC-769: Fix `start_date_field` description for retention policy assignment resource

Fixes DDOC-757, DDOC-769
