### PR TITLE
Fix issues with deploying content to EN / STAGING branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     # The following steps are performed for each lint job
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -45,7 +45,7 @@ jobs:
           pip install yamllint
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -76,7 +76,12 @@ jobs:
     # The following steps are performed for each lint job
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Compile the content
         run: |
@@ -166,7 +171,12 @@ jobs:
     # The following steps are performed for each lint job
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Compile the content
         run: |


### PR DESCRIPTION
# Description

Pushing content to en branch didn't work properly. The issue is the runner image: https://github.com/actions/runner-images/blob/ubuntu22/20230305.1/images/linux/Ubuntu2204-Readme.md that has node version 18, and it causes issues with webpack.

To fix this we need to override the Node version in the workflow.


Fixes DDOC-793

