### PR TITLE
Fix file variant - Base instead of Mini

### DIFF
--- a/content/requests/sign_request_create_request.yml
+++ b/content/requests/sign_request_create_request.yml
@@ -15,10 +15,10 @@ allOf:
       source_files:
         type: array
         items:
-          $ref: '#/components/schemas/File--Mini'
+          $ref: '#/components/schemas/File--Base'
         description: |-
           List of files to create a signing document from. This is currently
-          limited to 10 files. Only the ID and type fields are required
+          limited to 10 files. Only the `ID` and `type` fields are required
           for each file. The array will be empty if the `source_files`
           are deleted.
         minimum: 1


### PR DESCRIPTION
# Description

File variant for creating sign requests should be base, not mini - as source_files param returns just ID and type fields.

