### PR TITLE
DDOC-825: Make required fields optional

### DIFF
--- a/content/responses/file--mini.yml
+++ b/content/responses/file--mini.yml
@@ -10,10 +10,6 @@ description: |-
   A mini representation of a file, used when
   nested under another resource.
 
-required:
-  - sequence_id
-  - sha1
-
 allOf:
   - $ref: '#/components/schemas/File--Base'
   - properties:

--- a/content/responses/file.yml
+++ b/content/responses/file.yml
@@ -10,16 +10,6 @@ description: |-
   A standard representation of a file, as returned from any
   file API endpoints by default
 
-required:
-  - description
-  - size
-  - path_collection
-  - created_at
-  - modified_at
-  - modified_by
-  - owned_by
-  - item_status
-
 allOf:
   - $ref: '#/components/schemas/File--Mini'
   - properties:

--- a/content/responses/folder.yml
+++ b/content/responses/folder.yml
@@ -10,15 +10,6 @@ description: |-
   A standard representation of a folder, as returned from any
   folder API endpoints by default
 
-required:
-  - size
-  - path_collection
-  - created_by
-  - modified_by
-  - owned_by
-  - item_status
-  - item_collection
-
 allOf:
   - $ref: '#/components/schemas/Folder--Mini'
   - properties:

--- a/content/responses/user--mini.yml
+++ b/content/responses/user--mini.yml
@@ -10,10 +10,6 @@ description: |-
   A mini representation of a user, as can be returned when nested within other
   resources.
 
-required:
-  - name
-  - login
-
 allOf:
   - $ref: '#/components/schemas/User--Base'
   - properties:

--- a/content/responses/user_collaborations.yml
+++ b/content/responses/user_collaborations.yml
@@ -10,10 +10,6 @@ description: |-
   A mini representation of a user, can be returned only when
   the status is `pending`.
 
-required:
-  - name
-  - login
-
 allOf:
   - $ref: '#/components/schemas/User--Base'
   - properties:


### PR DESCRIPTION
# Description

Turned required fields params in standard and mini responses to optional for the CodeGen to work properly. These specific parameters are values for fields parameter and do not have to be be marked as required.

Fixes DDOC-825
