### PR TITLE
fix: DDOC-672 Remove "id" parameter

### DIFF
--- a/content/paths/trashed_items__get_folders_trash_items.yml
+++ b/content/paths/trashed_items__get_folders_trash_items.yml
@@ -39,11 +39,10 @@ parameters:
       This parameter is not supported when using marker-based pagination.
     in: query
     required: false
-    example: id
+    example: name
     schema:
       type: string
       enum:
-        - id
         - name
         - date
         - size


### PR DESCRIPTION
Removed "id" parameter example from the following endpoint: [get-folders-trash-items](https://developer.box.com/reference/get-folders-trash-items/) 

Solves [DDOC-672](https://jira.inside-box.net/browse/DDOC-672)