### PR TITLE
fix: DDOC-841: Add info about enhanced password

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -58,3 +58,4 @@ period
 uri
 url 
 dropdown
+special

--- a/content/attributes/shared_link-writable.yml
+++ b/content/attributes/shared_link-writable.yml
@@ -32,9 +32,11 @@ properties:
     description: |-
       The password required to access the shared link. Set the
       password to `null` to remove it.
-
+      Passwords must now be at least eight characters
+      long and include a number, upper case letter, or
+      a non-numeric or non-alphabetical character.
       A password can only be set when `access` is set to `open`.
-    example: "do-not-use-this-password"
+    example: "do-n8t-use-this-Password"
 
   vanity_name:
     type: string

--- a/content/paths/shared_links_files__put_files_id--add_shared_link.yml
+++ b/content/paths/shared_links_files__put_files_id--add_shared_link.yml
@@ -57,9 +57,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/shared_links_files__put_files_id--update_shared_link.yml
+++ b/content/paths/shared_links_files__put_files_id--update_shared_link.yml
@@ -55,9 +55,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/shared_links_folders__put_folders_id--add_shared_link.yml
+++ b/content/paths/shared_links_folders__put_folders_id--add_shared_link.yml
@@ -58,9 +58,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/shared_links_folders__put_folders_id--update_shared_link.yml
+++ b/content/paths/shared_links_folders__put_folders_id--update_shared_link.yml
@@ -55,9 +55,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/shared_links_web_links__put_web_links_id--add_shared_link.yml
+++ b/content/paths/shared_links_web_links__put_web_links_id--add_shared_link.yml
@@ -58,9 +58,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/shared_links_web_links__put_web_links_id--update_shared_link.yml
+++ b/content/paths/shared_links_web_links__put_web_links_id--update_shared_link.yml
@@ -55,9 +55,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/web_links__post_web_links.yml
+++ b/content/paths/web_links__post_web_links.yml
@@ -83,9 +83,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/web_links__put_web_links_id.yml
+++ b/content/paths/web_links__put_web_links_id.yml
@@ -78,6 +78,9 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
                 example: "do-not-use-this-password"
 

--- a/content/paths/web_links__put_web_links_id.yml
+++ b/content/paths/web_links__put_web_links_id.yml
@@ -78,7 +78,6 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-.
                   A password can only be set when `access` is set to `open`.
                 example: "do-not-use-this-password"
 

--- a/content/paths/web_links__put_web_links_id.yml
+++ b/content/paths/web_links__put_web_links_id.yml
@@ -78,9 +78,11 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-
+                  Passwords must now be at least eight characters
+                  long and include a number, upper case letter, or
+                  a non-numeric or non-alphabetical character.
                   A password can only be set when `access` is set to `open`.
-                example: "do-not-use-this-password"
+                example: "do-n8t-use-this-Password"
 
               vanity_name:
                 type: string

--- a/content/paths/web_links__put_web_links_id.yml
+++ b/content/paths/web_links__put_web_links_id.yml
@@ -78,11 +78,9 @@ requestBody:
                 description: |-
                   The password required to access the shared link. Set the
                   password to `null` to remove it.
-                  Passwords must now be at least eight characters
-                  long and include a number, upper case letter, or
-                  a non-numeric or non-alphabetical character.
+.
                   A password can only be set when `access` is set to `open`.
-                example: "do-n8t-use-this-Password"
+                example: "do-not-use-this-password"
 
               vanity_name:
                 type: string


### PR DESCRIPTION
# Description

Update `shared_link.password` parameter with new requirements.

Fixes `DDOC-841`

