### PR TITLE
fix: DDOC-822:  Update description of `sort` param for List Folder Items API

### DIFF
--- a/content/paths/folders__get_folders_id_items.yml
+++ b/content/paths/folders__get_folders_id_items.yml
@@ -25,18 +25,27 @@ parameters:
   - $ref: '../attributes/offset.yml'
   - $ref: '../attributes/limit.yml'
   - $ref: '../attributes/boxapi_header.yml'
-
+  # yamllint disable rule:line-length
   - name: sort
     description: |-
       Defines the **second** attribute by which items
       are sorted.
 
-      Items are always sorted by their `type` first, with
-      folders listed before files, and files listed
-      before web links.
+      The folder type affects the way the items
+      are sorted:
 
-      This parameter is not supported for marker-based pagination
-      on the root folder (the folder with an ID of `0`).
+      * **Standard folder**:
+        Items are always sorted by their `type` first, with
+        folders listed before files, and files listed
+        before web links.
+
+      * **Root folder**:
+        This parameter is not supported for marker-based pagination
+        on the root folder (the folder with an `id` of `0`).
+
+      * **Shared folder with parent path to the associated folder visible to the user**:
+        Items are sorted by `id` regardless of the parameter value.
+
     in: query
     required: false
     example: id
@@ -47,7 +56,7 @@ parameters:
         - name
         - date
         - size
-
+  # yamllint disable rule:line-length
   - $ref: '../attributes/direction.yml'
 
 responses:

--- a/content/paths/folders__get_folders_id_items.yml
+++ b/content/paths/folders__get_folders_id_items.yml
@@ -44,7 +44,9 @@ parameters:
         on the root folder (the folder with an `id` of `0`).
 
       * **Shared folder with parent path to the associated folder visible to the collaborator**:
-        Items are sorted by `id` regardless of the parameter value.
+        Items are always sorted by their `type` first, with
+        folders listed before files, and files listed
+        before web links.
 
     in: query
     required: false

--- a/content/paths/folders__get_folders_id_items.yml
+++ b/content/paths/folders__get_folders_id_items.yml
@@ -43,7 +43,7 @@ parameters:
         This parameter is not supported for marker-based pagination
         on the root folder (the folder with an `id` of `0`).
 
-      * **Shared folder with parent path to the associated folder visible to the user**:
+      * **Shared folder with parent path to the associated folder visible to the collaborator**:
         Items are sorted by `id` regardless of the parameter value.
 
     in: query


### PR DESCRIPTION
# Description

 Updated description of `sort` param for List Folder Items API to include the sorting behavior for items in shared folders with parent path visible to the user.
Staging: https://staging.developer.box.com/reference/get-folders-id-items/#param-sort
Fixes # DDOC-822

