### PR TITLE
feat: APIWG-349 add search response type at root result

### DIFF
--- a/content/responses/search_results.yml
+++ b/content/responses/search_results.yml
@@ -12,6 +12,14 @@ description: |-
 allOf:
   - $ref: "../attributes/search_result_collection.yml"
   - properties:
+      type:
+        description: |-
+          Specifies the response as search result items without shared links
+        type: string
+        example: search_results_items
+        enum:
+          - search_results_items
+        nullable: false
       entries:
         description: |-
           The search results for the query provided.

--- a/content/responses/search_results.yml
+++ b/content/responses/search_results.yml
@@ -29,3 +29,4 @@ allOf:
             - $ref: '#/components/schemas/File'
             - $ref: '#/components/schemas/Folder'
             - $ref: '#/components/schemas/WebLink'
+

--- a/content/responses/search_results.yml
+++ b/content/responses/search_results.yml
@@ -29,4 +29,3 @@ allOf:
             - $ref: '#/components/schemas/File'
             - $ref: '#/components/schemas/Folder'
             - $ref: '#/components/schemas/WebLink'
-

--- a/content/responses/search_results_with_shared_links.yml
+++ b/content/responses/search_results_with_shared_links.yml
@@ -17,6 +17,14 @@ description: |-
 allOf:
   - $ref: "../attributes/search_result_collection.yml"
   - properties:
+      type:
+        description: |-
+          Specifies the response as search result items with shared links
+        type: string
+        example: search_results_with_shared_links
+        enum:
+          - search_results_with_shared_links
+        nullable: false
       entries:
         description: |-
           The search results for the query provided, including the


### PR DESCRIPTION
Search endpoints can return two types of results. Add "type" field at root search response to easly determine which kind it is.
APIWG-349