### PR TITLE
docs: Storage policies: endpoints only accessible by admin

### DIFF
--- a/content/paths/storage_policies__get_storage_policies.yml
+++ b/content/paths/storage_policies__get_storage_policies.yml
@@ -10,7 +10,7 @@ x-box-tag: storage_policies
 
 description: |-
   Fetches all the storage policies in the enterprise.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:

--- a/content/paths/storage_policies__get_storage_policies.yml
+++ b/content/paths/storage_policies__get_storage_policies.yml
@@ -10,6 +10,8 @@ x-box-tag: storage_policies
 
 description: |-
   Fetches all the storage policies in the enterprise.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 parameters:
   - $ref: '../attributes/fields.yml'

--- a/content/paths/storage_policies__get_storage_policies_id.yml
+++ b/content/paths/storage_policies__get_storage_policies_id.yml
@@ -9,7 +9,7 @@ tags:
 x-box-tag: storage_policies
 
 description: Fetches a specific storage policy.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:

--- a/content/paths/storage_policies__get_storage_policies_id.yml
+++ b/content/paths/storage_policies__get_storage_policies_id.yml
@@ -9,6 +9,8 @@ tags:
 x-box-tag: storage_policies
 
 description: Fetches a specific storage policy.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 parameters:
   - $ref: '../attributes/storage_policy_id.yml'

--- a/content/paths/storage_policy_assignments__delete_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__delete_storage_policy_assignments_id.yml
@@ -18,6 +18,9 @@ description: |-
   There is a rate limit for calling this endpoint of only
   twice per user in a 24 hour time frame.
 
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
+
 parameters:
   - $ref: '../attributes/storage_policy_assignment_id.yml'
 

--- a/content/paths/storage_policy_assignments__delete_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__delete_storage_policy_assignments_id.yml
@@ -18,7 +18,7 @@ description: |-
   There is a rate limit for calling this endpoint of only
   twice per user in a 24 hour time frame.
 
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:

--- a/content/paths/storage_policy_assignments__get_storage_policy_assignments.yml
+++ b/content/paths/storage_policy_assignments__get_storage_policy_assignments.yml
@@ -10,7 +10,7 @@ x-box-tag: storage_policy_assignments
 
 description: |-
   Fetches all the storage policy assignment for an enterprise or user.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:

--- a/content/paths/storage_policy_assignments__get_storage_policy_assignments.yml
+++ b/content/paths/storage_policy_assignments__get_storage_policy_assignments.yml
@@ -10,6 +10,8 @@ x-box-tag: storage_policy_assignments
 
 description: |-
   Fetches all the storage policy assignment for an enterprise or user.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 parameters:
   - $ref: '../attributes/marker.yml'

--- a/content/paths/storage_policy_assignments__get_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__get_storage_policy_assignments_id.yml
@@ -9,7 +9,7 @@ tags:
 x-box-tag: storage_policy_assignments
 
 description: Fetches a specific storage policy assignment.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:

--- a/content/paths/storage_policy_assignments__get_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__get_storage_policy_assignments_id.yml
@@ -9,6 +9,8 @@ tags:
 x-box-tag: storage_policy_assignments
 
 description: Fetches a specific storage policy assignment.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 parameters:
   - $ref: '../attributes/storage_policy_assignment_id.yml'

--- a/content/paths/storage_policy_assignments__post_storage_policy_assignments.yml
+++ b/content/paths/storage_policy_assignments__post_storage_policy_assignments.yml
@@ -10,7 +10,7 @@ x-box-tag: storage_policy_assignments
 
 description: |-
   Creates a storage policy assignment for an enterprise or user.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 requestBody:

--- a/content/paths/storage_policy_assignments__post_storage_policy_assignments.yml
+++ b/content/paths/storage_policy_assignments__post_storage_policy_assignments.yml
@@ -10,6 +10,8 @@ x-box-tag: storage_policy_assignments
 
 description: |-
   Creates a storage policy assignment for an enterprise or user.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 requestBody:
   content:

--- a/content/paths/storage_policy_assignments__put_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__put_storage_policy_assignments_id.yml
@@ -9,6 +9,8 @@ tags:
 x-box-tag: storage_policy_assignments
 
 description: Updates a specific storage policy assignment.
+  This endpoint can be accessed only by a Primary Admin. The user
+  needs to generate a token for an account to authenticate this request.
 
 parameters:
   - $ref: '../attributes/storage_policy_assignment_id.yml'

--- a/content/paths/storage_policy_assignments__put_storage_policy_assignments_id.yml
+++ b/content/paths/storage_policy_assignments__put_storage_policy_assignments_id.yml
@@ -9,7 +9,7 @@ tags:
 x-box-tag: storage_policy_assignments
 
 description: Updates a specific storage policy assignment.
-  This endpoint can be accessed only by a Primary Admin. The user
+  Only a Primary Admin can access this endpoint. The user
   needs to generate a token for an account to authenticate this request.
 
 parameters:


### PR DESCRIPTION
Add information about the storage policy endpoints: 

- can be accessed only by primary Admin
- user needs to generate a token for an account to authenticate the request

Closed [DDOC-690](https://jira.inside-box.net/browse/DDOC-690)