### PR TITLE
fix: DDOC-854: Add query params for GET folders endpoint

### DIFF
--- a/content/attributes/sort.yml
+++ b/content/attributes/sort.yml
@@ -1,0 +1,42 @@
+---
+name: sort
+description: |-
+  Defines the **second** attribute by which items
+  are sorted.
+
+  The folder type affects the way the items
+  are sorted:
+
+    * **Standard folder**:
+    Items are always sorted by
+    their `type` first, with
+    folders listed before files,
+    and files listed
+    before web links.
+
+    * **Root folder**:
+    This parameter is not supported
+    for marker-based pagination
+    on the root folder
+
+    (the folder with an `id` of `0`).
+
+    * **Shared folder with parent path
+    to the associated folder visible to
+    the collaborator**:
+    Items are always sorted by
+    their `type` first, with
+    folders listed before files,
+    and files listed
+    before web links.
+
+in: query
+required: false
+example: id
+schema:
+  type: string
+  enum:
+    - id
+    - name
+    - date
+    - size

--- a/content/paths/folders__get_folders_id.yml
+++ b/content/paths/folders__get_folders_id.yml
@@ -14,7 +14,12 @@ description: |-
   Retrieves details for a folder, including the first 100 entries
   in the folder.
 
-  To fetch more items within the folder, please use the
+  Passing `sort`, `direction`, `offset`, and `limit`
+  parameters in query allows you to manage the
+  list of returned
+  [folder items](r://folder--full#param-item-collection).
+
+  To fetch more items within the folder, use the
   [Get items in a folder](#get-folders-id-items) endpoint.
 
 parameters:
@@ -22,13 +27,21 @@ parameters:
   - $ref: '../attributes/fields--with_metadata.yml'
   - $ref: '../attributes/if_none_match.yml'
   - $ref: '../attributes/boxapi_header.yml'
+  - $ref: '../attributes/sort.yml'
+  - $ref: '../attributes/direction.yml'
+  - $ref: '../attributes/offset.yml'
+  - $ref: '../attributes/limit.yml'
+
 
 responses:
   200:
     description: |-
       Returns a folder, including the first 100 entries in the folder.
+      If you used query parameters like
+      `sort`, `direction`, `offset`, or `limit`
+      the *folder items list* will be affected accordingly.
 
-      To fetch more items within the folder, please use the
+      To fetch more items within the folder, use the
       [Get items in a folder](#get-folders-id-items) endpoint.
 
       Not all available fields are returned by default. Use the

--- a/content/paths/folders__get_folders_id_items.yml
+++ b/content/paths/folders__get_folders_id_items.yml
@@ -15,7 +15,7 @@ description: |-
   folders, and web links.
 
   To request more information about the folder itself, like its size,
-  please use the [Get a folder](#get-folders-id) endpoint instead.
+  use the [Get a folder](#get-folders-id) endpoint instead.
 
 parameters:
   - $ref: '../attributes/folder_id.yml'
@@ -25,40 +25,7 @@ parameters:
   - $ref: '../attributes/offset.yml'
   - $ref: '../attributes/limit.yml'
   - $ref: '../attributes/boxapi_header.yml'
-  # yamllint disable rule:line-length
-  - name: sort
-    description: |-
-      Defines the **second** attribute by which items
-      are sorted.
-
-      The folder type affects the way the items
-      are sorted:
-
-      * **Standard folder**:
-        Items are always sorted by their `type` first, with
-        folders listed before files, and files listed
-        before web links.
-
-      * **Root folder**:
-        This parameter is not supported for marker-based pagination
-        on the root folder (the folder with an `id` of `0`).
-
-      * **Shared folder with parent path to the associated folder visible to the collaborator**:
-        Items are always sorted by their `type` first, with
-        folders listed before files, and files listed
-        before web links.
-
-    in: query
-    required: false
-    example: id
-    schema:
-      type: string
-      enum:
-        - id
-        - name
-        - date
-        - size
-  # yamllint disable rule:line-length
+  - $ref: '../attributes/sort.yml'
   - $ref: '../attributes/direction.yml'
 
 responses:

--- a/src/spectral/ensurePropertiesExample.js
+++ b/src/spectral/ensurePropertiesExample.js
@@ -27,7 +27,7 @@ module.exports =(item, _, paths) => {
   if (!item.example && item.example !== false) {
     return [
       {
-        message: `${paths.target ? paths.target.join('.') : 'property'} is not truthy`,
+        message: `${paths.target ? paths.target.join('.') : 'property'} requires an example`,
       }
     ]
   }

--- a/src/spectral/ensureSchemaHasType.js
+++ b/src/spectral/ensureSchemaHasType.js
@@ -2,7 +2,7 @@ module.exports = (schema, _, paths) => {
   if (schema.oneOf) { return }
   if (!schema.type && !schema['$ref']) {
     return [{
-      message: `${paths.target ? paths.target.join('.') : 'type or $ref'} is not truthy`,
+      message: `${paths.target ? paths.target.join('.') : 'type or $ref'} requires a type property`,
     }]
   }
 }

--- a/src/spectral/ensureSimpleDescription.js
+++ b/src/spectral/ensureSimpleDescription.js
@@ -20,7 +20,7 @@ module.exports = (item, _, paths) => {
   if (!item.description) {
     return [
       {
-        message: `${paths.target ? paths.target.join('.') : 'property'} requires description.`,
+        message: `${paths.target ? paths.target.join('.') : 'property'} requires a description`,
       }
     ]
   }

--- a/src/spectral/ensureSimpleDescription.js
+++ b/src/spectral/ensureSimpleDescription.js
@@ -20,7 +20,7 @@ module.exports = (item, _, paths) => {
   if (!item.description) {
     return [
       {
-        message: `${paths.target ? paths.target.join('.') : 'property'} is not truthy`,
+        message: `${paths.target ? paths.target.join('.') : 'property'} requires description.`,
       }
     ]
   }


### PR DESCRIPTION
# Description

Added the `sort`, `limit`, `offset`, and `direction` query params to the GET folders endpoint.

Fixes `DDOC-854`
On staging: https://staging.developer.box.com/reference/get-folders-id/


Additional changes: improved spectral / linter messages wording
