### PR TITLE
feat: DDOC-856 add `finalizing` and `error_finalizing` status to Sign Request resource

### DIFF
--- a/content/responses/sign_request.yml
+++ b/content/responses/sign_request.yml
@@ -80,6 +80,8 @@ allOf:
           - error_converting
           - error_sending
           - expired
+          - finalizing
+          - error_finalizing
         example: converting
         description: 'Describes the status of the sign request'
 


### PR DESCRIPTION
# Description

Add `finalizing` and `error_finalizing` status to  https://developer.box.com/reference/resources/sign-request/#param-status


Fixes DDOC-856

