### PR TITLE
feat: add collections to PUT files endpoint

### DIFF
--- a/content/paths/files__put_files_id.yml
+++ b/content/paths/files__put_files_id.yml
@@ -18,7 +18,6 @@ parameters:
   - $ref: '../attributes/file_id.yml'
   - $ref: '../attributes/fields.yml'
   - $ref: '../attributes/if_match.yml'
-
 requestBody:
   content:
     application/json:
@@ -109,6 +108,23 @@ requestBody:
                 enum:
                   - open
                   - company
+
+          collections:
+            type: array
+            description: |-
+              An array of collections to make this file
+              a member of. Currently
+              we only support the `favorites` collection.
+
+              To get the ID for a collection, use the
+              [List all collections][1] endpoint.
+
+              Passing an empty array `[]` or `null` will remove
+              the file from all collections.
+
+              [1]: ../advanced-files-and-folders/#get-collections
+            items:
+              $ref: "../attributes/reference.yml"
 
           tags:
             $ref: "../attributes/tags.yml"

--- a/content/paths/files__put_files_id.yml
+++ b/content/paths/files__put_files_id.yml
@@ -122,7 +122,7 @@ requestBody:
               Passing an empty array `[]` or `null` will remove
               the file from all collections.
 
-              [1]: ../advanced-files-and-folders/#get-collections
+              [1]: e://get-collections
             items:
               $ref: "../attributes/reference.yml"
 

--- a/content/paths/folders__put_folders_id.yml
+++ b/content/paths/folders__put_folders_id.yml
@@ -88,7 +88,7 @@ requestBody:
               Passing an empty array `[]` or `null` will remove
               the folder from all collections.
 
-              [1]: ../advanced-files-and-folders/#get-collections
+              [1]: e://get-collections
             items:
               $ref: "../attributes/reference.yml"
 


### PR DESCRIPTION
# Description

Missing collections schema from PUT files endpoint. It is already referenced in the guides https://developer.box.com/guides/collections/add/. Basically same as for Folders - https://developer.box.com/reference/put-folders-id/#param-collections

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
