### PR TITLE
fix: DDOC-862: Add note on recommended ZIP archive size

### DIFF
--- a/content/paths/zip_downloads__post_zip_downloads.yml
+++ b/content/paths/zip_downloads__post_zip_downloads.yml
@@ -17,7 +17,15 @@ description: |-
   archive.
 
   The limit for an archive is either the Account's upload limit or
-  10,000 files, whichever is met first
+  10,000 files, whichever is met first.
+
+  **Note**: Downloading a large file can be
+  affected by various
+  factors such as distance, network latency,
+  bandwidth, and congestion, as well as packet loss
+  ratio and current server load.
+  For these reasons we recommend that a maximum ZIP archive
+  total size does not exceed 25GB.
 
 requestBody:
   content:


### PR DESCRIPTION
# Description

Added note about recommended maxiumum ZIP archive size

Fixes DDOC-862

Staging preview: https://staging.developer.box.com/reference/post-zip-downloads/