### PR TITLE
fix: DDOC-861: Remove share link param from POST

### DIFF
--- a/content/paths/web_links__post_web_links.yml
+++ b/content/paths/web_links__post_web_links.yml
@@ -51,66 +51,6 @@ requestBody:
             description: |-
               Description of the web link.
 
-          shared_link:
-            description: |-
-              The settings for the shared link to update.
-
-            type: object
-            properties:
-              access:
-                type: string
-                description: |-
-                  The level of access for the shared link. This can be
-                  restricted to anyone with the link (`open`), only people
-                  within the company (`company`) and only those who
-                  have been invited to the folder (`collaborators`).
-
-                  If not set, this field defaults to the access level specified
-                  by the enterprise admin. To create a shared link with this
-                  default setting pass the `shared_link` object with
-                  no `access` field, for example `{ "shared_link": {} }`.
-
-                  The `company` access level is only available to paid
-                  accounts.
-                enum:
-                  - open
-                  - company
-                  - collaborators
-                example: "open"
-
-              password:
-                type: string
-                description: |-
-                  The password required to access the shared link. Set the
-                  password to `null` to remove it.
-                  Passwords must now be at least eight characters
-                  long and include a number, upper case letter, or
-                  a non-numeric or non-alphabetic character.
-                  A password can only be set when `access` is set to `open`.
-                example: "do-n8t-use-this-Password"
-
-              vanity_name:
-                type: string
-                description: |-
-                  Defines a custom vanity name to use in the shared link URL,
-                  for example `https://app.box.com/v/my-shared-link`.
-
-                  Custom URLs should not be used when sharing sensitive content
-                  as vanity URLs are a lot easier to guess than regular shared
-                  links.
-                minLength: 12
-                example: "my-shared-link"
-
-              unshared_at:
-                type: string
-                format: date-time
-                example: "2012-12-12T10:53:43-08:00"
-                description: |-
-                  The timestamp at which this shared link will
-                  expire. This field can only be set by
-                  users with paid accounts. The value must be greater than the
-                  current date and time.
-
 responses:
   200:
     description:


### PR DESCRIPTION
# Description

Remove share link param from POST, because shared links are created with PUT, POST doesn't work.

Fixes DDOC-861


