### PR TITLE
fix: DDOC-868: mark fields as required

### DIFF
--- a/content/paths/collaborations__post_collaborations.yml
+++ b/content/paths/collaborations__post_collaborations.yml
@@ -42,9 +42,6 @@ requestBody:
             type: object
             description: |-
               The item to attach the comment to.
-            required:
-              - id
-              - type
             properties:
               type:
                 type: string

--- a/content/paths/comments__post_comments.yml
+++ b/content/paths/comments__post_comments.yml
@@ -22,6 +22,7 @@ requestBody:
         type: object
         required:
           - message
+          - item
         properties:
           message:
             type: string

--- a/content/paths/tasks__post_tasks.yml
+++ b/content/paths/tasks__post_tasks.yml
@@ -25,9 +25,6 @@ requestBody:
             type: object
             description: |-
               The file to attach the task to.
-            required:
-              - id
-              - type
             properties:
               id:
                 type: string


### PR DESCRIPTION
# Description

Marked `item.id` and `item.type` fields for comments (https://developer.box.com/reference/post-comments/) endpoint as required.
Staging: https://staging.developer.box.com/reference/post-comments/

Fixes DDOC-868 


