### PR TITLE
feat: DDOC-855 add iframeable_embed_url param to box sign request

### DIFF
--- a/content/paths/file_metadata__get_files_id_metadata_id_id.yml
+++ b/content/paths/file_metadata__get_files_id_metadata_id_id.yml
@@ -27,7 +27,7 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/Metadata'
+          $ref: '#/components/schemas/Metadata--Full'
 
   403:
     description: |-

--- a/content/paths/memberships__post_group_memberships.yml
+++ b/content/paths/memberships__post_group_memberships.yml
@@ -70,7 +70,7 @@ requestBody:
               Setting these permissions overwrites the default
               access levels of an admin.
 
-              Specifying a value of "null" for this object will disable
+              Specifying a value of "null" for this object will deactivate
               all configurable permissions. Specifying permissions will set
               them accordingly, omitted permissions will be enabled by default.
             additionalProperties:

--- a/content/paths/memberships__put_group_memberships_id.yml
+++ b/content/paths/memberships__put_group_memberships_id.yml
@@ -43,7 +43,7 @@ requestBody:
               Setting these permissions overwrites the default
               access levels of an admin.
 
-              Specifying a value of "null" for this object will disable
+              Specifying a value of "null" for this object will deactivate
               all configurable permissions. Specifying permissions will set
               them accordingly, omitted permissions will be enabled by default.
             additionalProperties:

--- a/content/schemas/sign_request_signer.yml
+++ b/content/schemas/sign_request_signer.yml
@@ -45,7 +45,7 @@ allOf:
         example: https://example.com
         description: URL to direct a signer to for signing
 
-<!-- yamllint-disable line-length -->
+      # yamllint disable rule:line-length
 
       iframeable_embed_url:
         type: string
@@ -53,8 +53,9 @@ allOf:
         example: https://app.box.com/embed/sign/document/f14d7098-a331-494b-808b-79bc7f3992a3/f14d7098-a331-494b-808b-79bc7f3992a4
         description: |-
           This URL is specifically designed for
-          signing documents within an HTML iframe tag.
+          signing documents within an HTML `iframe` tag.
           The first ID in the URL represents the signature
-          request ID, while the second ID (the last part) represents the signer's ID.
+          request ID, while the second ID (the last part)
+          represents the signer's ID.
 
-<!-- yamllint-enable line-length -->
+      # yamllint enable rule:line-length

--- a/content/schemas/sign_request_signer.yml
+++ b/content/schemas/sign_request_signer.yml
@@ -50,7 +50,7 @@ allOf:
       iframeable_embed_url:
         type: string
         nullable: true
-        example: https://app.box.com/embed/sign/document/f14d7098-a331-494b-808b-79bc7f3992a3/f14d7098-a331-494b-808b-79bc7f3992a4
+        example: https://app.box.com/embed/sign/document/gfhr4222-a331-494b-808b-79bc7f3992a3/f14d7098-a331-494b-808b-79bc7f3992a4
         description: |-
           This URL is specifically designed for
           signing documents within an HTML `iframe` tag.

--- a/content/schemas/sign_request_signer.yml
+++ b/content/schemas/sign_request_signer.yml
@@ -44,3 +44,17 @@ allOf:
         readOnly: true
         example: https://example.com
         description: URL to direct a signer to for signing
+
+<!-- yamllint-disable line-length -->
+
+      iframeable_embed_url:
+        type: string
+        nullable: true
+        example: https://app.box.com/embed/sign/document/f14d7098-a331-494b-808b-79bc7f3992a3/f14d7098-a331-494b-808b-79bc7f3992a4
+        description: |-
+          This URL is specifically designed for
+          signing documents within an HTML iframe tag.
+          The first ID in the URL represents the signature
+          request ID, while the second ID (the last part) represents the signer's ID.
+
+<!-- yamllint-enable line-length -->

--- a/content/schemas/sign_request_signer.yml
+++ b/content/schemas/sign_request_signer.yml
@@ -54,8 +54,9 @@ allOf:
         description: |-
           This URL is specifically designed for
           signing documents within an HTML `iframe` tag.
-          The first ID in the URL represents the signature
-          request ID, while the second ID (the last part)
-          represents the signer's ID.
+          It will be returned in the response
+          only if the `embed_url_external_user_id`
+          parameter was passed in the
+          `create sign request` call.
 
       # yamllint enable rule:line-length


### PR DESCRIPTION
# Description

Add iframeable_embed_url param to box sign request to provide support for signing documents within an HTML iframe tag.
staging: https://staging.developer.box.com/reference/resources/sign-request/#param-signers-iframeable_embed_url
A part of DDOC-855 (along with guide improvements and changelog entry).

