### PR TITLE
fix: DDOC-871: add info on params for mappings

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -59,3 +59,4 @@ uri
 url 
 dropdown
 special
+org

--- a/content/schemas/integration_mapping_partner_item_slack.yml
+++ b/content/schemas/integration_mapping_partner_item_slack.yml
@@ -26,8 +26,8 @@ properties:
     type: string
     example: 'T12352314'
     description: ID of the Slack workspace with which the item is associated.
-     Use this parameter if Box for Slack is installed at a workspace level. Do not
-     use `slack_org_id` at the same time.
+     Use this parameter if Box for Slack is installed at a workspace level.
+     Do not use `slack_org_id` at the same time.
     nullable: true
   slack_org_id:
     type: string

--- a/content/schemas/integration_mapping_partner_item_slack.yml
+++ b/content/schemas/integration_mapping_partner_item_slack.yml
@@ -32,7 +32,7 @@ properties:
   slack_org_id:
     type: string
     example: 'E1234567'
-    description: ID of the Slack organization with which the item is associated.
+    description: ID of the Slack org with which the item is associated.
        Use this parameter if Box for Slack is installed at the org level.
        Do not use `slack_workspace_id` at the same time.
     nullable: true

--- a/content/schemas/integration_mapping_partner_item_slack.yml
+++ b/content/schemas/integration_mapping_partner_item_slack.yml
@@ -4,7 +4,11 @@ title: Integration mapping mapped item schema for type Slack
 type: object
 
 description: |-
-  The schema for an integration mapping mapped item object for type Slack
+  The schema for an integration mapping mapped item object for type Slack.
+
+  Depending if Slack is installed at the organization or team level,
+  provide **either** `slack_org_id` **or** `slack_workspace_id`.
+  Do not use both parameters at the same time.
 
 properties:
   type:
@@ -21,12 +25,16 @@ properties:
   slack_workspace_id:
     type: string
     example: 'T12352314'
-    description: ID of the Slack workspace with which the item is associated
+    description: ID of the Slack workspace with which the item is associated.
+     Use this parameter if Slack is installed at a team level. Do not
+     use `slack_org_id` at the same time.
     nullable: true
   slack_org_id:
     type: string
     example: 'E1234567'
-    description: ID of the Slack organization with which the item is associated
+    description: ID of the Slack organization with which the item is associated.
+       Use this parameter if Slack is installed at the organization level.
+       Do not use `slack_workspace_id` at the same time.
     nullable: true
 
 required:

--- a/content/schemas/integration_mapping_partner_item_slack.yml
+++ b/content/schemas/integration_mapping_partner_item_slack.yml
@@ -6,7 +6,7 @@ type: object
 description: |-
   The schema for an integration mapping mapped item object for type Slack.
 
-  Depending if Slack is installed at the organization or team level,
+  Depending if Box for Slack is installed at the org or workspace level,
   provide **either** `slack_org_id` **or** `slack_workspace_id`.
   Do not use both parameters at the same time.
 
@@ -26,14 +26,14 @@ properties:
     type: string
     example: 'T12352314'
     description: ID of the Slack workspace with which the item is associated.
-     Use this parameter if Slack is installed at a team level. Do not
+     Use this parameter if Box for Slack is installed at a workspace level. Do not
      use `slack_org_id` at the same time.
     nullable: true
   slack_org_id:
     type: string
     example: 'E1234567'
     description: ID of the Slack organization with which the item is associated.
-       Use this parameter if Slack is installed at the organization level.
+       Use this parameter if Box for Slack is installed at the org level.
        Do not use `slack_workspace_id` at the same time.
     nullable: true
 


### PR DESCRIPTION
# Description

Add more information to `slack_workspace_id` and `slack_org_id` params for integration mappings.
Staging preview: https://staging.developer.box.com/reference/post-integration-mappings-slack/#param-partner_item

Fixes # DDOC-871
