### PR TITLE
fix: Add `integer` value to metadata template response

### DIFF
--- a/content/attributes/metadata_field--readable.yml
+++ b/content/attributes/metadata_field--readable.yml
@@ -1,5 +1,5 @@
 ---
-title: Metadata Field (Write)
+title: Metadata Field (Read)
 
 description: |-
   A field within a metadata template. Fields can be a basic text, date, or

--- a/content/attributes/metadata_field--readable.yml
+++ b/content/attributes/metadata_field--readable.yml
@@ -1,0 +1,75 @@
+---
+title: Metadata Field (Write)
+
+description: |-
+  A field within a metadata template. Fields can be a basic text, date, or
+  number field, or a list of options.
+
+required:
+  - type
+  - key
+  - displayName
+
+type: object
+
+properties:
+  type:
+    type: string
+    example: string
+    description: |-
+      The type of field. The basic fields are a `string` field for text, a
+      `float` field for numbers, and a `date` fields to present the user with a
+      date-time picker.
+
+      Additionally, metadata templates support an `enum` field for a basic list
+      of items, and ` multiSelect` field for a similar list of items where the
+      user can select more than one value.
+
+      **Note**: The `integer` value is deprecated. 
+      It is still present in the response,
+      but cannot be used in the POST request.
+    enum:
+      - string
+      - float
+      - date
+      - enum
+      - multiSelect
+      - integer
+
+  key:
+    type: string
+    example: category
+    description: |-
+      A unique identifier for the field. The identifier must
+      be unique within the template to which it belongs.
+    maxLength: 256
+
+  displayName:
+    type: string
+    example: Category
+    description: |-
+      The display name of the field as it is shown to the user in the web and
+      mobile apps.
+    maxLength: 4096
+
+  description:
+    type: string
+    example: The category
+    description: |-
+      A description of the field. This is not shown to the user.
+    maxLength: 4096
+
+  hidden:
+    type: boolean
+    example: true
+    description: |-
+      Whether this field is hidden in the UI for the user and can only be set
+      through the API instead.
+
+  options:
+    description: |-
+      A list of options for this field. This is used in combination with the
+      `enum` and `multiSelect` field types.
+    type: array
+    items:
+      $ref: "../attributes/metadata_option--writable.yml"

--- a/content/attributes/metadata_field--readable.yml
+++ b/content/attributes/metadata_field--readable.yml
@@ -25,7 +25,7 @@ properties:
       of items, and ` multiSelect` field for a similar list of items where the
       user can select more than one value.
 
-      **Note**: The `integer` value is deprecated. 
+      **Note**: The `integer` value is deprecated.
       It is still present in the response,
       but cannot be used in the POST request.
     enum:

--- a/content/responses/metadata_template.yml
+++ b/content/responses/metadata_template.yml
@@ -76,7 +76,7 @@ properties:
         number field, or a list of options.
 
       allOf:
-        - $ref: '../attributes/metadata_field--writable.yml'
+        - $ref: '../attributes/metadata_field--readable.yml'
         - properties:
             id:
               type: string


### PR DESCRIPTION
# Description

Added the `integer` value to metadata template response (only, not present in the request on purpose) along with the note that it is deprecated.
