### PR TITLE
fix: mark type as required in search results

### DIFF
--- a/content/responses/search_results.yml
+++ b/content/responses/search_results.yml
@@ -9,6 +9,9 @@ x-box-tag: search
 description: |-
   A list of files, folders and web links that matched the search query.
 
+required:
+  - type
+
 allOf:
   - $ref: "../attributes/search_result_collection.yml"
   - properties:

--- a/content/responses/search_results_with_shared_links.yml
+++ b/content/responses/search_results_with_shared_links.yml
@@ -14,6 +14,9 @@ description: |-
   This response format is only returned when the `include_recent_shared_links`
   query parameter has been set to `true`.
 
+required:
+  - type
+
 allOf:
   - $ref: "../attributes/search_result_collection.yml"
   - properties:

--- a/openapi.json
+++ b/openapi.json
@@ -31856,6 +31856,9 @@
         "x-box-resource-id": "search_results",
         "x-box-tag": "search",
         "description": "A list of files, folders and web links that matched the search query.",
+        "required": [
+          "type"
+        ],
         "allOf": [
           {
             "type": "object",
@@ -31918,6 +31921,9 @@
         "x-box-resource-id": "search_results_with_shared_links",
         "x-box-tag": "search",
         "description": "A list of files, folders and web links that matched the search query,\nincluding the additional information about any shared links through\nwhich the item has been shared with the user.\n\nThis response format is only returned when the `include_recent_shared_links`\nquery parameter has been set to `true`.",
+        "required": [
+          "type"
+        ],
         "allOf": [
           {
             "type": "object",


### PR DESCRIPTION
Needed for correct deserialization of search response in box-typescript-sdk-gen