### PR TITLE
fix: Added label field to TemplateSigner schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -33556,6 +33556,12 @@
                 "example": "example@mail.com",
                 "nullable": true
               },
+              "label":{
+                "type": "string",
+                "description": "Label of the signer",
+                "example": "Example Signer",
+                "nullable": true
+              },
               "role": {
                 "type": "string",
                 "enum": [


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed.

Added the label field to the TemplateSigner schema in the OpenAPI spec. When calling the list sign templates or get sign template by id endpoints of the Box API the sign template object that is returned contains Signer objects that contain a field called **label** that is undocumented in the OpenAPI spec.

`curl -L -X GET "https://api.box.com/2.0/sign_templates?limit=1000" \
     -H "authorization: Bearer <ACCESS_TOKEN>" \`

```json
{
	"type": "sign-template",
	"id": ...,
         ...,
	"signers": [
		{
			"email": "",
			>"label": "",
			"public_id": "",
			"role": "",
			"is_in_person": false,
			"order": 0,
			"signer_group_id": null,
			"inputs": ...
		}
	],
      ...
}
```

## Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own changes
- [✅] I have run `yarn lint` to make sure my changes pass all linters
- [✅] I have pulled the latest changes from the upstream developer branch
