### PR TITLE
docs: remove parameter from Sign page

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -14,7 +14,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     },
     "version": "2.0.0",
-    "x-box-commit-hash": "fd1d1837fd"
+    "x-box-commit-hash": "9ec0f8628c"
   },
   "servers": [
     {
@@ -27099,6 +27099,12 @@
                   "DOWNLOAD",
                   "EDIT",
                   "EDIT_USER",
+                  "EDR_CROWDSTRIKE_DEVICE_DETECTED",
+                  "EDR_CROWDSTRIKE_NO_BOX_TOOLS",
+                  "EDR_CROWDSTRIKE_BOX_TOOLS_OUTDATED",
+                  "EDR_CROWDSTRIKE_DRIVE_OUTDATED",
+                  "EDR_CROWDSTRIKE_ACCESS_ALLOWED_NO_CROWDSTRIKE_DEVICE",
+                  "EDR_CROWDSTRIKE_ACCESS_REVOKED",
                   "EMAIL_ALIAS_CONFIRM",
                   "EMAIL_ALIAS_REMOVE",
                   "ENABLE_TWO_FACTOR_AUTH",
@@ -34212,12 +34218,6 @@
             "example": "123",
             "nullable": true
           },
-          "is_phone_verification_required_to_view": {
-            "description": "Forces signers to verify a text message prior to viewing the document. You must specify the phone number of signers to have this setting apply to them.",
-            "type": "boolean",
-            "example": true,
-            "nullable": true
-          },
           "template_id": {
             "description": "When a signature request is created from a template this field will indicate the id of that template.",
             "type": "string",
@@ -34345,15 +34345,9 @@
             "nullable": true
           },
           "login_required": {
-            "description": "If set to true, the signer will need to log in to a Box account\nbefore signing the request. If the signer does not have\nan existing account, they will have the option to create\na free Box account. Cannot be selected in combination with\n`verification_phone_number`.",
+            "description": "If set to true, the signer will need to log in to a Box account\nbefore signing the request. If the signer does not have\nan existing account, they will have the option to create\na free Box account.",
             "type": "boolean",
             "example": true,
-            "nullable": true
-          },
-          "verification_phone_number": {
-            "description": "If set, this phone number will be used to verify the signer\nvia two-factor authentication before they are able to sign the document.\nCannot be selected in combination with `login_required`.",
-            "type": "string",
-            "example": "6314578901",
             "nullable": true
           },
           "password": {
@@ -39811,6 +39805,11 @@
       "name": "AI",
       "description": "A set of endpoints used to\ninteract with supported LLMs.",
       "x-box-tag": "ai"
+    },
+    {
+      "name": "AI Studio",
+      "description": "A set of endpoints used to\ninteract with AI Studio.",
+      "x-box-tag": "ai_studio"
     },
     {
       "name": "App item associations",


### PR DESCRIPTION
Removing `is_phone_verification_required `param from all Box Sign resources. This parameter will be true by default from now on and as such doesn't need to be visible in responses.
Closes [DDOC-1088](https://jira.inside-box.net/browse/DDOC-1088)