### PR TITLE
fix: Fix issues in box-openapi

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -14,7 +14,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     },
     "version": "2024.0",
-    "x-box-commit-hash": "f0be4386a8"
+    "x-box-commit-hash": "e3e3e24e9f"
   },
   "servers": [
     {
@@ -605,7 +605,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "An optional different name for the file. This can be used to\nrename the file.",
+                    "description": "An optional different name for the file. This can be used to\nrename the file.\n\nFile names must be unique within their parent folder. The name check is case-insensitive, so a file \nnamed `New File` cannot be created in a parent folder that already contains a folder named `new file`.",
                     "type": "string",
                     "example": "NewFile.txt"
                   },
@@ -1414,7 +1414,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "description": "The name of the file",
+                        "description": "The name of the file.\n\nFile names must be unique within their parent folder. The name check is case-insensitive, so a file\nnamed `New File` cannot be created in a parent folder that already contains a folder named `new file`.",
                         "type": "string",
                         "example": "Photo.png"
                       },
@@ -3316,7 +3316,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Returns an instance of the `securityClassification` metadata\ntemplate, which contains a `Box__Security__Classification__Key`\nfield that lists all the classifications available to this\nenterprise.",
             "content": {
               "application/json": {
@@ -5270,7 +5270,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "The optional new name for this folder.",
+                    "description": "The optional new name for this folder.\n\nThe following restrictions to folder names apply: names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), names with trailing spaces, and names `.` and `..` are\nnot allowed.\n\nFolder names must be unique within their parent folder. The name check is case-insensitive, \nso a folder named `New Folder` cannot be created in a parent folder that already contains \na folder named `new folder`.",
                     "type": "string",
                     "example": "New Folder"
                   },
@@ -5948,7 +5948,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "The name for the new folder.\n\nThere are some restrictions to the file name. Names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), as well as names with trailing spaces are\nprohibited.\n\nAdditionally, the names `.` and `..` are\nnot allowed either.",
+                    "description": "The name for the new folder.\n\nThe following restrictions to folder names apply: names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), names with trailing spaces, and names `.` and `..` are\nnot allowed.\n\nFolder names must be unique within their parent folder. The name check is case-insensitive, \nso a folder named `New Folder` cannot be created in a parent folder that already contains \na folder named `new folder`.",
                     "type": "string",
                     "example": "New Folder",
                     "maxLength": 255,
@@ -6525,7 +6525,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Returns an instance of the `securityClassification` metadata\ntemplate, which contains a `Box__Security__Classification__Key`\nfield that lists all the classifications available to this\nenterprise.",
             "content": {
               "application/json": {

--- a/openapi/openapi-v2025.0.json
+++ b/openapi/openapi-v2025.0.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "Box Platform API",
-    "description": "common/description.md",
+    "description": "[Box Platform](https://box.dev) provides functionality to provide access to content stored within [Box](https://box.com). It provides endpoints for basic manipulation of files and folders, management of users within an enterprise, as well as more complex topics such as legal holds and retention policies.",
     "termsOfService": "https://cloud.app.box.com/s/rmwxu64h1ipr41u49w3bbuvbsa29wku9",
     "contact": {
       "name": "Box, Inc",
@@ -14,7 +14,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     },
     "version": "2025.0",
-    "x-box-commit-hash": "f0be4386a8"
+    "x-box-commit-hash": "e3e3e24e9f"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -14,7 +14,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     },
     "version": "2024.0",
-    "x-box-commit-hash": "f0be4386a8"
+    "x-box-commit-hash": "e3e3e24e9f"
   },
   "servers": [
     {
@@ -605,7 +605,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "An optional different name for the file. This can be used to\nrename the file.",
+                    "description": "An optional different name for the file. This can be used to\nrename the file.\n\nFile names must be unique within their parent folder. The name check is case-insensitive, so a file \nnamed `New File` cannot be created in a parent folder that already contains a folder named `new file`.",
                     "type": "string",
                     "example": "NewFile.txt"
                   },
@@ -1414,7 +1414,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "description": "The name of the file",
+                        "description": "The name of the file.\n\nFile names must be unique within their parent folder. The name check is case-insensitive, so a file\nnamed `New File` cannot be created in a parent folder that already contains a folder named `new file`.",
                         "type": "string",
                         "example": "Photo.png"
                       },
@@ -3316,7 +3316,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Returns an instance of the `securityClassification` metadata\ntemplate, which contains a `Box__Security__Classification__Key`\nfield that lists all the classifications available to this\nenterprise.",
             "content": {
               "application/json": {
@@ -5270,7 +5270,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "The optional new name for this folder.",
+                    "description": "The optional new name for this folder.\n\nThe following restrictions to folder names apply: names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), names with trailing spaces, and names `.` and `..` are\nnot allowed.\n\nFolder names must be unique within their parent folder. The name check is case-insensitive, \nso a folder named `New Folder` cannot be created in a parent folder that already contains \na folder named `new folder`.",
                     "type": "string",
                     "example": "New Folder"
                   },
@@ -5948,7 +5948,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "description": "The name for the new folder.\n\nThere are some restrictions to the file name. Names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), as well as names with trailing spaces are\nprohibited.\n\nAdditionally, the names `.` and `..` are\nnot allowed either.",
+                    "description": "The name for the new folder.\n\nThe following restrictions to folder names apply: names containing\nnon-printable ASCII characters, forward and backward slashes\n(`/`, `\\`), names with trailing spaces, and names `.` and `..` are\nnot allowed.\n\nFolder names must be unique within their parent folder. The name check is case-insensitive, \nso a folder named `New Folder` cannot be created in a parent folder that already contains \na folder named `new folder`.",
                     "type": "string",
                     "example": "New Folder",
                     "maxLength": 255,
@@ -6525,7 +6525,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Returns an instance of the `securityClassification` metadata\ntemplate, which contains a `Box__Security__Classification__Key`\nfield that lists all the classifications available to this\nenterprise.",
             "content": {
               "application/json": {


### PR DESCRIPTION
Update response status codes to 200 for security classification endpoints.

Update folder and file name restrictions in API specifications.

Closes:

https://github.com/box/box-openapi/issues/436
https://github.com/box/box-openapi/issues/371